### PR TITLE
Add support for rapier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
   struct Data { timer: ReflectedUI<Timer> }
   ```
 - [allow multiple inspector windows](https://github.com/jakobhellermann/bevy-inspector-egui/commit/980de51e181fe486ac74312474c33a34e0a77293)
+- add `InspectableWithContext` trait which exposes `bevy::ecs::Resources` to the ui function
+  This is used to display things like `Asset<T>`.
+  To use this trait the plugin needs to be initialized using `app.add_plugin(ThreadLocalInspectorPlugin::<T>::new())`
 
 ### Changed
 - [rename NumberAttributes::step to speed](https://github.com/jakobhellermann/bevy-inspector-egui/commit/b2aeb1735bdf0b5d8d68386e22f1e73437cbf733)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,12 @@ exclude = ["docs/*"]
 
 [features]
 nightly = []
+rapier = ["bevy_rapier3d"]
 
 [dependencies]
 bevy = { version = "0.4", default-features = false }
 bevy_egui = { version = "0.1", default-features = false }
+bevy_rapier3d = { version = "0.7.0", optional = true }
 
 bevy-inspector-egui-derive = { path = "bevy-inspector-egui-derive" }
 # bevy-inspector-egui-derive = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,8 @@ nightly = []
 bevy = { version = "0.4", default-features = false }
 bevy_egui = { version = "0.1", default-features = false }
 
-# bevy-inspector-egui-derive = { path = "bevy-inspector-egui-derive" }
-bevy-inspector-egui-derive = "0.2"
+bevy-inspector-egui-derive = { path = "bevy-inspector-egui-derive" }
+# bevy-inspector-egui-derive = "0.2"
 
 [dev-dependencies]
 bevy = { version = "0.4", default-features = false, features = ["x11", "render", "bevy_wgpu", "bevy_winit"] }

--- a/bevy-inspector-egui-derive/src/lib.rs
+++ b/bevy-inspector-egui-derive/src/lib.rs
@@ -7,8 +7,19 @@ pub fn inspectable(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let input = syn::parse_macro_input!(input as syn::DeriveInput);
 
     match &input.data {
-        syn::Data::Struct(data) => inspectable_struct::expand_struct(&input, data).into(),
+        syn::Data::Struct(data) => inspectable_struct::expand_struct(&input, data, false).into(),
         syn::Data::Enum(data) => inspectable_enum::expand_enum(&input, data).into(),
+        syn::Data::Union(_) => unimplemented!(),
+    }
+}
+
+#[proc_macro_derive(InspectableWithContext, attributes(inspectable))]
+pub fn inspectable_with_context(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let input = syn::parse_macro_input!(input as syn::DeriveInput);
+
+    match &input.data {
+        syn::Data::Struct(data) => inspectable_struct::expand_struct(&input, data, true).into(),
+        syn::Data::Enum(_) => unimplemented!(),
         syn::Data::Union(_) => unimplemented!(),
     }
 }

--- a/examples/inspectable_with_context.rs
+++ b/examples/inspectable_with_context.rs
@@ -1,0 +1,51 @@
+use bevy::prelude::*;
+use bevy_inspector_egui::{InspectableWithContext, ThreadLocalInspectorPlugin};
+
+// #[derive(Inspectable, Debug)]
+#[derive(InspectableWithContext, Default, Debug)]
+struct Data {
+    material: Handle<StandardMaterial>,
+}
+
+fn main() {
+    App::build()
+        .add_plugins(DefaultPlugins)
+        .add_plugin(ThreadLocalInspectorPlugin::<Data>::new())
+        .add_startup_system(setup.system())
+        .run();
+}
+
+struct Cube;
+
+fn setup(
+    commands: &mut Commands,
+    mut data: ResMut<Data>,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+) {
+    let material = materials.add(Color::rgb(0.8, 0.7, 0.6).into());
+    data.material = material.clone();
+
+    commands
+        .spawn(PbrBundle {
+            mesh: meshes.add(Mesh::from(shape::Plane { size: 5.0 })),
+            material: materials.add(Color::rgb(0.3, 0.5, 0.3).into()),
+            ..Default::default()
+        })
+        .spawn(PbrBundle {
+            mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
+            material,
+            transform: Transform::from_translation(Vec3::new(0.0, 0.5, 0.0)),
+            ..Default::default()
+        })
+        .with(Cube)
+        .spawn(LightBundle {
+            transform: Transform::from_translation(Vec3::new(4.0, 8.0, 4.0)),
+            ..Default::default()
+        })
+        .spawn(Camera3dBundle {
+            transform: Transform::from_translation(Vec3::new(-2.0, 2.5, 5.0))
+                .looking_at(Vec3::default(), Vec3::unit_y()),
+            ..Default::default()
+        });
+}

--- a/src/impls/bevy_impls.rs
+++ b/src/impls/bevy_impls.rs
@@ -99,3 +99,25 @@ impl Inspectable for Color {
         }
     }
 }
+
+impl Inspectable for StandardMaterial {
+    type Attributes = ();
+
+    fn ui(&mut self, ui: &mut egui::Ui, _: Self::Attributes) {
+        ui.vertical_centered(|ui| {
+            crate::egui::Grid::new(std::any::TypeId::of::<StandardMaterial>()).show(ui, |ui| {
+                ui.label("albedo");
+                self.albedo.ui(ui, Default::default());
+                ui.end_row();
+
+                ui.label("albedo_texture");
+                ui.label("<todo>");
+                ui.end_row();
+
+                ui.label("shaded");
+                self.shaded.ui(ui, Default::default());
+                ui.end_row();
+            });
+        });
+    }
+}

--- a/src/impls/mod.rs
+++ b/src/impls/mod.rs
@@ -5,6 +5,7 @@ mod list;
 mod number;
 mod primitives;
 mod vec;
+mod with_context;
 
 pub use bevy_impls::ColorAttributes;
 pub use number::NumberAttributes;

--- a/src/impls/mod.rs
+++ b/src/impls/mod.rs
@@ -11,3 +11,6 @@ pub use bevy_impls::ColorAttributes;
 pub use number::NumberAttributes;
 pub use primitives::StringAttributes;
 pub use vec::Vec2dAttributes;
+
+#[cfg(feature = "rapier")]
+mod rapier;

--- a/src/impls/rapier.rs
+++ b/src/impls/rapier.rs
@@ -1,0 +1,43 @@
+use crate::{Context, Inspectable, InspectableWithContext};
+use bevy_rapier3d::{
+    physics::RigidBodyHandleComponent,
+    rapier::dynamics::{RigidBody, RigidBodySet},
+};
+
+impl Inspectable for RigidBody {
+    type Attributes = ();
+
+    fn ui(&mut self, ui: &mut bevy_egui::egui::Ui, _options: Self::Attributes) {
+        ui.label("Mass");
+        self.mass().ui(ui, Default::default());
+    }
+}
+
+impl InspectableWithContext for RigidBodyHandleComponent {
+    type Attributes = <RigidBody as Inspectable>::Attributes;
+
+    fn ui_with_context(
+        &mut self,
+        ui: &mut bevy_egui::egui::Ui,
+        options: Self::Attributes,
+        context: &Context,
+    ) {
+        let mut bodies = match context.resources.get_mut::<RigidBodySet>() {
+            Some(bodies) => bodies,
+            None => {
+                ui.label("RigidBodySet is a required resource but is missing");
+                return;
+            }
+        };
+
+        let body = match bodies.get_mut(self.handle()) {
+            Some(body) => body,
+            None => {
+                ui.label("This handle does not exist on RigidBodySet");
+                return;
+            }
+        };
+
+        body.ui_with_context(ui, options, context);
+    }
+}

--- a/src/impls/with_context.rs
+++ b/src/impls/with_context.rs
@@ -1,0 +1,36 @@
+use crate::{Context, InspectableWithContext};
+use bevy::{
+    asset::{Asset, HandleId},
+    prelude::*,
+};
+use bevy_egui::egui;
+
+impl<T: Asset + InspectableWithContext> InspectableWithContext for Handle<T> {
+    type Attributes = T::Attributes;
+
+    fn ui_with_context(&mut self, ui: &mut egui::Ui, options: Self::Attributes, context: &Context) {
+        if self.id == HandleId::default::<T>() {
+            ui.label("<default handle>");
+            return;
+        }
+
+        let mut assets = match context.resources.get_mut::<Assets<T>>() {
+            Some(assets) => assets,
+            None => {
+                let msg = format!("No Assets resource for {}", std::any::type_name::<T>());
+                ui.label(msg);
+                return;
+            }
+        };
+        let value = match assets.get_mut(self.clone()) {
+            Some(val) => val,
+            None => {
+                let msg = format!("No value for handle {:?}", self);
+                ui.label(msg);
+                return;
+            }
+        };
+
+        value.ui_with_context(ui, options, context);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,8 +47,8 @@ pub mod reflect;
 pub use bevy_egui::egui;
 
 /// Derives the [`Inspectable`](Inspectable) trait.
-pub use bevy_inspector_egui_derive::Inspectable;
-pub use plugin::InspectorPlugin;
+pub use bevy_inspector_egui_derive::{Inspectable, InspectableWithContext};
+pub use plugin::{InspectorPlugin, ThreadLocalInspectorPlugin};
 
 /// Attributes for the built-in [`Inspectable`](Inspectable) implementations
 pub mod options {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,9 @@ pub mod reflect;
 pub use bevy_egui::egui;
 
 /// Derives the [`Inspectable`](Inspectable) trait.
-pub use bevy_inspector_egui_derive::{Inspectable, InspectableWithContext};
+pub use bevy_inspector_egui_derive::Inspectable;
+/// Derives the [`InspectableWithContext`](InspectableWithContext) trait.
+pub use bevy_inspector_egui_derive::InspectableWithContext;
 pub use plugin::{InspectorPlugin, ThreadLocalInspectorPlugin};
 
 /// Attributes for the built-in [`Inspectable`](Inspectable) implementations

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -3,7 +3,7 @@ use std::{any::TypeId, marker::PhantomData};
 use bevy::prelude::*;
 use bevy_egui::{egui, EguiContext, EguiPlugin};
 
-use crate::Inspectable;
+use crate::{Context, Inspectable, InspectableWithContext};
 
 #[derive(Default)]
 #[allow(missing_debug_implementations)]
@@ -11,9 +11,19 @@ use crate::Inspectable;
 /// See the [crate-level docs](index.html) for an example on how to use it.
 pub struct InspectorPlugin<T>(PhantomData<T>);
 
-impl<T> InspectorPlugin<T> {
+#[derive(Default)]
+#[allow(missing_debug_implementations)]
+/// Bevy plugin for using [`InspectableWithContext`](crate::InspectableWithContext).
+pub struct ThreadLocalInspectorPlugin<T>(PhantomData<T>);
+
+impl<T: Inspectable> InspectorPlugin<T> {
     pub fn new() -> Self {
         InspectorPlugin(PhantomData)
+    }
+}
+impl<T: InspectableWithContext> ThreadLocalInspectorPlugin<T> {
+    pub fn new() -> Self {
+        ThreadLocalInspectorPlugin(PhantomData)
     }
 }
 
@@ -26,6 +36,50 @@ impl InspectorWindows {
     fn contains_name(&self, name: &str) -> bool {
         self.0.iter().any(|(_, n)| n == name)
     }
+    fn get_unwrap<T: 'static>(&self) -> &str {
+        self.0
+            .get(&TypeId::of::<T>())
+            .expect("inspector window not properly initialized")
+    }
+}
+
+fn build_inspector_plugin<T>(app: &mut AppBuilder)
+where
+    T: Default + Send + Sync + 'static,
+{
+    // init inspector ui and data resource
+    app.init_resource::<T>();
+
+    // init egui
+    if !app.resources().contains::<EguiContext>() {
+        app.add_plugin(EguiPlugin);
+    }
+
+    // add entry to `InspectorWindows`
+    let mut inspector_windows = app
+        .resources_mut()
+        .get_or_insert_with(InspectorWindows::default);
+
+    let type_id = TypeId::of::<T>();
+    let full_type_name = std::any::type_name::<T>();
+
+    if inspector_windows.contains_id(type_id) {
+        panic!(
+            "InspectorPlugin for {} is already registered",
+            full_type_name,
+        );
+    }
+
+    let type_name = full_type_name.rsplit("::").next().unwrap_or("Inspector");
+    if inspector_windows.contains_name(type_name) {
+        assert!(
+            !inspector_windows.contains_name(full_type_name),
+            "two types with different type_id but same type_name"
+        );
+        inspector_windows.0.insert(type_id, full_type_name.into());
+    } else {
+        inspector_windows.0.insert(type_id, type_name.into());
+    }
 }
 
 impl<T> Plugin for InspectorPlugin<T>
@@ -33,39 +87,18 @@ where
     T: Inspectable + Default + Send + Sync + 'static,
 {
     fn build(&self, app: &mut AppBuilder) {
-        // init inspector ui and data resource
-        app.init_resource::<T>().add_system(ui::<T>.system());
+        build_inspector_plugin::<T>(app);
+        app.add_system(ui::<T>.system());
+    }
+}
 
-        // init egui
-        if !app.resources().contains::<EguiContext>() {
-            app.add_plugin(EguiPlugin);
-        }
-
-        // add entry to `InspectorWindows`
-        let mut inspector_windows = app
-            .resources_mut()
-            .get_or_insert_with(InspectorWindows::default);
-
-        let type_id = TypeId::of::<T>();
-        let full_type_name = std::any::type_name::<T>();
-
-        if inspector_windows.contains_id(type_id) {
-            panic!(
-                "InspectorPlugin for {} is already registered",
-                full_type_name,
-            );
-        }
-
-        let type_name = full_type_name.rsplit("::").next().unwrap_or("Inspector");
-        if inspector_windows.contains_name(type_name) {
-            if inspector_windows.contains_name(full_type_name) {
-                panic!("two types with different type_id but same type_name");
-            } else {
-                inspector_windows.0.insert(type_id, full_type_name.into());
-            }
-        } else {
-            inspector_windows.0.insert(type_id, type_name.into());
-        }
+impl<T> Plugin for ThreadLocalInspectorPlugin<T>
+where
+    T: InspectableWithContext + Default + Send + Sync + 'static,
+{
+    fn build(&self, app: &mut AppBuilder) {
+        build_inspector_plugin::<T>(app);
+        app.add_system(thread_local_ui::<T>.system());
     }
 }
 
@@ -78,14 +111,29 @@ fn ui<T>(
 {
     let ctx = &mut egui_context.ctx;
 
-    let type_name = inspector_windows
-        .0
-        .get(&TypeId::of::<T>())
-        .expect("inspector window not properly initialized");
-
+    let type_name = inspector_windows.get_unwrap::<T>();
     egui::Window::new(type_name)
         .resizable(false)
         .show(ctx, |ui| {
             data.ui(ui, T::Attributes::default());
+        });
+}
+
+fn thread_local_ui<T>(_: &mut World, resources: &mut Resources)
+where
+    T: InspectableWithContext + Send + Sync + 'static,
+{
+    let egui_context = resources.get::<EguiContext>().unwrap();
+    let inspector_windows = resources.get_mut::<InspectorWindows>().unwrap();
+    let mut data = resources.get_mut::<T>().unwrap();
+
+    let type_name = inspector_windows.get_unwrap::<T>();
+
+    let ctx = &egui_context.ctx;
+    egui::Window::new(type_name)
+        .resizable(false)
+        .show(ctx, |ui| {
+            let context = Context { resources };
+            data.ui_with_context(ui, T::Attributes::default(), &context);
         });
 }


### PR DESCRIPTION
Sadly because of Rust's trait rules, bevy-inspector-egui is responsible for implementing `Inspectable` for every third-party `bevy` crate (unless they, of course, do it themselves -- such is the balance of power). I use rapier, and would find it useful to have support for inspecting rapier components. This PR establishes a feature for rapier, and I'll add more UIs for rapier components as I work on the debugger.