### PR TITLE
Update bevy_egui to 0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,8 @@ nightly = []
 
 [dependencies]
 bevy = { version = "0.5", default-features = false }
-bevy_egui = { version = "0.4.2", default-features = false, features = ["open_url"] }
-emath = "0.11"
+bevy_egui = { version = "0.5", default-features = false, features = ["open_url"] }
+emath = "0.12"
 bevy_rapier3d = { version = "0.9", optional = true }
 bevy_rapier2d = { version = "0.9", optional = true }
 nalgebra = { version = "0.25", features = ["convert-glam"], optional = true }


### PR DESCRIPTION
I noticed this was behind the current bevy_egui release because I kept seeing multiple versions of bevy_egui being compiled so I decided to upgrade it.

I ran most examples as a sanity check and they all seemed to work. All the test also pass.

I tried updating other outdated crates, but it required actual change in the code.