### PR TITLE
add vec_as_dropdown example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ bevy_rapier2d = { version = "0.10", optional = true }
 nalgebra = { version = "0.27", features = ["convert-glam013"], optional = true }
 
 bevy-inspector-egui-derive = { version = "0.5", path = "bevy-inspector-egui-derive" }
+rand = "0.8.4"
 
 [dev-dependencies]
 bevy = { version = "0.5", default-features = false, features = ["x11", "render", "bevy_wgpu", "bevy_winit"] }

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -48,7 +48,10 @@ fn main() {
         .run();
 }
 
-fn text_update_system(data: Res<Data>, mut query: Query<&mut Text>) {
+fn text_update_system(
+    data: Res<Data>,
+    mut query: Query<&mut Text>,
+) {
     for mut text in query.iter_mut() {
         let text = &mut text.sections[0];
         text.value = data.text.clone();

--- a/examples/enum.rs
+++ b/examples/enum.rs
@@ -53,7 +53,10 @@ fn main() {
         .run();
 }
 
-fn print_inspector(inspector: Res<Inspector>, mut events: EventReader<Print>) {
+fn print_inspector(
+    inspector: Res<Inspector>,
+    mut events: EventReader<Print>,
+) {
     for _ in events.iter() {
         println!("{:?}", inspector.shape);
     }

--- a/examples/planet_demo.rs
+++ b/examples/planet_demo.rs
@@ -134,7 +134,11 @@ pub struct PlanetShape<'a> {
     noise: &'a NoiseSettings,
 }
 impl<'a> PlanetShape<'a> {
-    pub fn new(resolution: u8, radius: f32, noise_settings: &'a NoiseSettings) -> PlanetShape<'a> {
+    pub fn new(
+        resolution: u8,
+        radius: f32,
+        noise_settings: &'a NoiseSettings,
+    ) -> PlanetShape<'a> {
         assert!(resolution > 0);
 
         PlanetShape {
@@ -144,7 +148,10 @@ impl<'a> PlanetShape<'a> {
         }
     }
 
-    fn elevation_at_point(&self, point: Vec3) -> f32 {
+    fn elevation_at_point(
+        &self,
+        point: Vec3,
+    ) -> f32 {
         let settings = &self.noise;
         let noise_fn = noise::SuperSimplex::new();
 
@@ -168,7 +175,10 @@ impl<'a> PlanetShape<'a> {
         noise_value * settings.strength
     }
 
-    fn point_on_planet(&self, point_on_unit_sphere: Vec3) -> Vec3 {
+    fn point_on_planet(
+        &self,
+        point_on_unit_sphere: Vec3,
+    ) -> Vec3 {
         let elevation = self.elevation_at_point(point_on_unit_sphere);
         point_on_unit_sphere * self.radius * (1.0 + elevation)
     }

--- a/examples/quaternion.rs
+++ b/examples/quaternion.rs
@@ -37,7 +37,10 @@ fn main() {
         .run();
 }
 
-fn update(data: Res<Data>, mut query: Query<(&Cube, &mut Transform)>) {
+fn update(
+    data: Res<Data>,
+    mut query: Query<(&Cube, &mut Transform)>,
+) {
     for (_, mut transform) in query.iter_mut() {
         match data.which_one {
             WhichOne::Euler => transform.rotation = data.euler,

--- a/examples/rust_types.rs
+++ b/examples/rust_types.rs
@@ -28,7 +28,10 @@ struct Data {
     non_inspectable: NonInspectable,
 }
 
-fn change_bg_color(ui: &mut egui::Ui, mut content: impl FnMut(&mut egui::Ui)) {
+fn change_bg_color(
+    ui: &mut egui::Ui,
+    mut content: impl FnMut(&mut egui::Ui),
+) {
     ui.scope(|ui| {
         let bg_color = egui::Color32::from_rgb(41, 80, 80);
         ui.style_mut().visuals.widgets.inactive.bg_fill = bg_color;

--- a/examples/transform.rs
+++ b/examples/transform.rs
@@ -23,7 +23,10 @@ fn main() {
         .run();
 }
 
-fn update(data: Res<Data>, mut query: Query<(&Cube, &mut Transform)>) {
+fn update(
+    data: Res<Data>,
+    mut query: Query<(&Cube, &mut Transform)>,
+) {
     if !data.is_changed() {
         return;
     }

--- a/examples/vec_as_dropdown.rs
+++ b/examples/vec_as_dropdown.rs
@@ -1,0 +1,122 @@
+use bevy::prelude::*;
+use bevy_inspector_egui::{Inspectable, InspectorPlugin};
+use std::fmt::{Debug, Display};
+pub struct VecAsDropdown<T>
+where
+    T: Clone + Display + PartialEq,
+{
+    from: Vec<T>,
+    selected: usize,
+}
+
+impl<T> VecAsDropdown<T>
+where
+    T: Clone + Display + PartialEq,
+{
+    pub fn new(from_vec: Vec<T>) -> Self {
+        Self {
+            from: from_vec,
+            selected: 0,
+        }
+    }
+
+    pub fn selected_value(&self) -> T {
+        self.from[self.selected].clone()
+    }
+}
+
+impl<T> Default for VecAsDropdown<T>
+where
+    T: Clone + Display + PartialEq,
+{
+    fn default() -> Self {
+        Self {
+            from: Vec::new(),
+            selected: 0,
+        }
+    }
+}
+
+impl<T> Inspectable for VecAsDropdown<T>
+where
+    T: Clone + Display + PartialEq + Debug + Default,
+{
+    type Attributes = Vec<T>;
+
+    fn ui(
+        &mut self,
+        ui: &mut bevy_inspector_egui::egui::Ui,
+        _: Self::Attributes,
+        _: &bevy_inspector_egui::Context,
+    ) -> bool {
+        let mut display = T::default();
+        if self.from.len() > 0 {
+            display = self.from[self.selected].clone();
+        }
+        let hash = format!("{:?}", self.from);
+
+        bevy_inspector_egui::egui::ComboBox::from_id_source(hash)
+            .selected_text(format!("{}", display))
+            .show_ui(ui, |ui| {
+                for (index, value) in self.from.iter().enumerate() {
+                    ui.selectable_value(&mut self.selected, index, format!("{}", value));
+                }
+            });
+        true
+    }
+
+    fn setup(_: &mut AppBuilder) {
+        // eprintln!("Running setup code...");
+
+        // app.init_resource::<WhateverYouNeed>();
+    }
+}
+
+#[derive(Inspectable)]
+struct Data {
+    pub vec_of_ints: VecAsDropdown<u32>,
+    pub vec_of_strings: VecAsDropdown<String>,
+}
+
+impl Default for Data {
+    fn default() -> Self {
+        let vec_of_ints = VecAsDropdown::new(vec![100, 200, 300, 400]);
+        let vec_of_strings = VecAsDropdown::new(
+            vec!["Some", "Thing", "And Another"]
+                .iter()
+                .map(|s| s.to_string())
+                .collect(),
+        );
+        Data {
+            vec_of_ints,
+            vec_of_strings,
+        }
+    }
+}
+
+fn main() {
+    App::build()
+        .add_plugins(DefaultPlugins)
+        .add_plugin(InspectorPlugin::<Data>::new())
+        .add_startup_system(setup.system())
+        .run();
+}
+
+fn setup(
+    mut commands: Commands,
+    mut materials: ResMut<Assets<ColorMaterial>>,
+) {
+    let color = materials.add(Color::BLUE.into());
+
+    commands.spawn_bundle(OrthographicCameraBundle::new_2d());
+    commands.spawn_bundle(UiCameraBundle::default());
+    commands.spawn_bundle(SpriteBundle {
+        material: color,
+        sprite: Sprite {
+            size: Vec2::new(40.0, 40.0),
+            ..Default::default()
+        },
+        transform: Transform::from_translation(Vec3::default()),
+        ..Default::default()
+    });
+}

--- a/src/impls/bevy_impls.rs
+++ b/src/impls/bevy_impls.rs
@@ -63,7 +63,12 @@ impl_for_struct_delegate_fields!(
 impl Inspectable for shape::Box {
     type Attributes = ();
 
-    fn ui(&mut self, ui: &mut egui::Ui, _: Self::Attributes, context: &Context) -> bool {
+    fn ui(
+        &mut self,
+        ui: &mut egui::Ui,
+        _: Self::Attributes,
+        context: &Context,
+    ) -> bool {
         let mut changed = false;
 
         let mut min = Vec3::new(self.min_x, self.min_y, self.min_z);
@@ -130,7 +135,12 @@ impl Inspectable for Transform {
 impl Inspectable for GlobalTransform {
     type Attributes = <Transform as Inspectable>::Attributes;
 
-    fn ui(&mut self, ui: &mut egui::Ui, options: Self::Attributes, context: &Context) -> bool {
+    fn ui(
+        &mut self,
+        ui: &mut egui::Ui,
+        options: Self::Attributes,
+        context: &Context,
+    ) -> bool {
         let global_transform = std::mem::take(self);
 
         let mut transform = Transform {
@@ -154,7 +164,12 @@ impl Inspectable for GlobalTransform {
 impl Inspectable for Mat3 {
     type Attributes = ();
 
-    fn ui(&mut self, ui: &mut egui::Ui, _: Self::Attributes, context: &Context) -> bool {
+    fn ui(
+        &mut self,
+        ui: &mut egui::Ui,
+        _: Self::Attributes,
+        context: &Context,
+    ) -> bool {
         let mut changed = false;
         ui.vertical(|ui| {
             changed |= self.x_axis.ui(ui, Default::default(), context);
@@ -168,7 +183,12 @@ impl Inspectable for Mat3 {
 impl Inspectable for Mat4 {
     type Attributes = ();
 
-    fn ui(&mut self, ui: &mut egui::Ui, _: Self::Attributes, context: &Context) -> bool {
+    fn ui(
+        &mut self,
+        ui: &mut egui::Ui,
+        _: Self::Attributes,
+        context: &Context,
+    ) -> bool {
         let mut changed = false;
         ui.vertical(|ui| {
             changed |= self.x_axis.ui(ui, Default::default(), context);
@@ -188,7 +208,12 @@ pub struct ColorAttributes {
 impl Inspectable for Color {
     type Attributes = ColorAttributes;
 
-    fn ui(&mut self, ui: &mut egui::Ui, options: Self::Attributes, _: &Context) -> bool {
+    fn ui(
+        &mut self,
+        ui: &mut egui::Ui,
+        options: Self::Attributes,
+        _: &Context,
+    ) -> bool {
         let old: [f32; 4] = (*self).into();
 
         if options.alpha {
@@ -219,7 +244,12 @@ impl Inspectable for Color {
 impl Inspectable for AmbientLight {
     type Attributes = <Color as Inspectable>::Attributes;
 
-    fn ui(&mut self, ui: &mut egui::Ui, options: Self::Attributes, context: &Context) -> bool {
+    fn ui(
+        &mut self,
+        ui: &mut egui::Ui,
+        options: Self::Attributes,
+        context: &Context,
+    ) -> bool {
         let brightness_attributes = NumberAttributes::positive().speed(0.01);
 
         self.color.ui(ui, options, context);
@@ -229,7 +259,12 @@ impl Inspectable for AmbientLight {
 impl Inspectable for ClearColor {
     type Attributes = <Color as Inspectable>::Attributes;
 
-    fn ui(&mut self, ui: &mut egui::Ui, options: Self::Attributes, context: &Context) -> bool {
+    fn ui(
+        &mut self,
+        ui: &mut egui::Ui,
+        options: Self::Attributes,
+        context: &Context,
+    ) -> bool {
         self.0.ui(ui, options, context)
     }
 }
@@ -245,7 +280,12 @@ impl_for_struct_delegate_fields!(TextureAtlasSprite: color, index, flip_x, flip_
 impl Inspectable for TextureAtlas {
     type Attributes = ();
 
-    fn ui(&mut self, ui: &mut egui::Ui, _: Self::Attributes, context: &Context) -> bool {
+    fn ui(
+        &mut self,
+        ui: &mut egui::Ui,
+        _: Self::Attributes,
+        context: &Context,
+    ) -> bool {
         let mut changed = false;
         egui::Grid::new(context.id()).show(ui, |ui| {
             ui.label("texture");
@@ -338,7 +378,12 @@ impl Inspectable for StandardMaterial {
 impl Inspectable for Mesh {
     type Attributes = ();
 
-    fn ui(&mut self, ui: &mut egui::Ui, _: Self::Attributes, context: &Context) -> bool {
+    fn ui(
+        &mut self,
+        ui: &mut egui::Ui,
+        _: Self::Attributes,
+        context: &Context,
+    ) -> bool {
         Grid::new(context.id()).show(ui, |ui| {
             ui.label("Primitive Topology");
             let _ = ui.button(format!("{:?}", self.primitive_topology()));
@@ -385,7 +430,12 @@ impl Inspectable for Mesh {
 impl Inspectable for Name {
     type Attributes = ();
 
-    fn ui(&mut self, ui: &mut egui::Ui, _: Self::Attributes, _: &Context) -> bool {
+    fn ui(
+        &mut self,
+        ui: &mut egui::Ui,
+        _: Self::Attributes,
+        _: &Context,
+    ) -> bool {
         ui.label(self.as_str());
         false
     }
@@ -394,7 +444,12 @@ impl Inspectable for Name {
 impl Inspectable for VisibleEntities {
     type Attributes = ();
 
-    fn ui(&mut self, ui: &mut egui::Ui, _: Self::Attributes, _: &Context) -> bool {
+    fn ui(
+        &mut self,
+        ui: &mut egui::Ui,
+        _: Self::Attributes,
+        _: &Context,
+    ) -> bool {
         let len = self.value.len();
         let entity = match len {
             1 => "entity",
@@ -408,7 +463,12 @@ impl Inspectable for VisibleEntities {
 impl<'a, T: Inspectable> Inspectable for Mut<'a, T> {
     type Attributes = T::Attributes;
 
-    fn ui(&mut self, ui: &mut egui::Ui, options: Self::Attributes, context: &Context) -> bool {
+    fn ui(
+        &mut self,
+        ui: &mut egui::Ui,
+        options: Self::Attributes,
+        context: &Context,
+    ) -> bool {
         (**self).ui(ui, options, context)
     }
 }

--- a/src/impls/list.rs
+++ b/src/impls/list.rs
@@ -9,7 +9,12 @@ where
 {
     type Attributes = <T as Inspectable>::Attributes;
 
-    fn ui(&mut self, ui: &mut egui::Ui, options: Self::Attributes, context: &Context) -> bool {
+    fn ui(
+        &mut self,
+        ui: &mut egui::Ui,
+        options: Self::Attributes,
+        context: &Context,
+    ) -> bool {
         let mut changed = false;
 
         ui.vertical(|ui| {
@@ -53,7 +58,12 @@ where
 impl<T: Inspectable, const N: usize> Inspectable for [T; N] {
     type Attributes = <T as Inspectable>::Attributes;
 
-    fn ui(&mut self, ui: &mut egui::Ui, options: Self::Attributes, context: &Context) -> bool {
+    fn ui(
+        &mut self,
+        ui: &mut egui::Ui,
+        options: Self::Attributes,
+        context: &Context,
+    ) -> bool {
         let mut changed = false;
         ui.vertical(|ui| {
             for (i, val) in self.iter_mut().enumerate() {

--- a/src/impls/number.rs
+++ b/src/impls/number.rs
@@ -24,7 +24,10 @@ impl<T> Default for NumberAttributes<T> {
 }
 
 impl<T> NumberAttributes<T> {
-    pub(crate) fn map<U>(&self, f: impl Fn(&T) -> U) -> NumberAttributes<U> {
+    pub(crate) fn map<U>(
+        &self,
+        f: impl Fn(&T) -> U,
+    ) -> NumberAttributes<U> {
         NumberAttributes {
             min: self.min.as_ref().map(|v| f(v)),
             max: self.max.as_ref().map(f),
@@ -42,7 +45,10 @@ impl<T> NumberAttributes<T> {
         }
     }
 
-    pub fn between(min: T, max: T) -> Self {
+    pub fn between(
+        min: T,
+        max: T,
+    ) -> Self {
         NumberAttributes {
             min: Some(min),
             max: Some(max),
@@ -50,7 +56,10 @@ impl<T> NumberAttributes<T> {
         }
     }
 
-    pub(crate) fn speed(self, speed: f32) -> Self {
+    pub(crate) fn speed(
+        self,
+        speed: f32,
+    ) -> Self {
         NumberAttributes { speed, ..self }
     }
 }
@@ -94,7 +103,12 @@ impl Num for usize {}
 impl<T: Num> Inspectable for T {
     type Attributes = NumberAttributes<T>;
 
-    fn ui(&mut self, ui: &mut egui::Ui, options: Self::Attributes, _: &Context) -> bool {
+    fn ui(
+        &mut self,
+        ui: &mut egui::Ui,
+        options: Self::Attributes,
+        _: &Context,
+    ) -> bool {
         let mut widget = widgets::DragValue::new(self);
 
         if !options.prefix.is_empty() {

--- a/src/impls/primitives.rs
+++ b/src/impls/primitives.rs
@@ -20,7 +20,12 @@ pub struct StringAttributes {
 impl Inspectable for String {
     type Attributes = StringAttributes;
 
-    fn ui(&mut self, ui: &mut egui::Ui, options: Self::Attributes, _: &Context) -> bool {
+    fn ui(
+        &mut self,
+        ui: &mut egui::Ui,
+        options: Self::Attributes,
+        _: &Context,
+    ) -> bool {
         let widget = match options.multiline {
             false => widgets::TextEdit::singleline(self),
             true => widgets::TextEdit::multiline(self),
@@ -33,7 +38,12 @@ impl Inspectable for String {
 impl<'a> Inspectable for &'a str {
     type Attributes = ();
 
-    fn ui(&mut self, ui: &mut egui::Ui, _: Self::Attributes, _: &Context) -> bool {
+    fn ui(
+        &mut self,
+        ui: &mut egui::Ui,
+        _: Self::Attributes,
+        _: &Context,
+    ) -> bool {
         ui.label(*self);
         false
     }
@@ -41,7 +51,12 @@ impl<'a> Inspectable for &'a str {
 
 impl Inspectable for bool {
     type Attributes = ();
-    fn ui(&mut self, ui: &mut egui::Ui, _: Self::Attributes, _: &Context) -> bool {
+    fn ui(
+        &mut self,
+        ui: &mut egui::Ui,
+        _: Self::Attributes,
+        _: &Context,
+    ) -> bool {
         ui.checkbox(self, "").changed()
     }
 }
@@ -52,7 +67,12 @@ where
 {
     type Attributes = T::Attributes;
 
-    fn ui(&mut self, ui: &mut egui::Ui, options: Self::Attributes, context: &Context) -> bool {
+    fn ui(
+        &mut self,
+        ui: &mut egui::Ui,
+        options: Self::Attributes,
+        context: &Context,
+    ) -> bool {
         let mut changed = false;
         ui.horizontal(|ui| {
             let replacement = T::default()..=T::default();
@@ -74,7 +94,12 @@ where
 {
     type Attributes = T::Attributes;
 
-    fn ui(&mut self, ui: &mut egui::Ui, options: Self::Attributes, context: &Context) -> bool {
+    fn ui(
+        &mut self,
+        ui: &mut egui::Ui,
+        options: Self::Attributes,
+        context: &Context,
+    ) -> bool {
         let mut changed = false;
         ui.horizontal(|ui| {
             changed |= self.start.ui(ui, options.clone(), &context.with_id(0));
@@ -112,7 +137,12 @@ impl<T: Inspectable> Default for OptionAttributes<T> {
 impl<T: Inspectable> Inspectable for Option<T> {
     type Attributes = OptionAttributes<T>;
 
-    fn ui(&mut self, ui: &mut egui::Ui, options: Self::Attributes, context: &Context) -> bool {
+    fn ui(
+        &mut self,
+        ui: &mut egui::Ui,
+        options: Self::Attributes,
+        context: &Context,
+    ) -> bool {
         let mut changed = false;
         match self {
             Some(val) => {
@@ -141,7 +171,12 @@ impl<T: Inspectable> Inspectable for Option<T> {
 impl Inspectable for Duration {
     type Attributes = ();
 
-    fn ui(&mut self, ui: &mut egui::Ui, _: Self::Attributes, context: &Context) -> bool {
+    fn ui(
+        &mut self,
+        ui: &mut egui::Ui,
+        _: Self::Attributes,
+        context: &Context,
+    ) -> bool {
         let mut seconds = self.as_secs_f32();
         let attributes = NumberAttributes {
             min: Some(0.0),

--- a/src/impls/quat.rs
+++ b/src/impls/quat.rs
@@ -34,7 +34,12 @@ struct AxisAngle((Vec3, f32));
 impl Inspectable for Quat {
     type Attributes = QuatAttributes;
 
-    fn ui(&mut self, ui: &mut egui::Ui, options: Self::Attributes, context: &Context) -> bool {
+    fn ui(
+        &mut self,
+        ui: &mut egui::Ui,
+        options: Self::Attributes,
+        context: &Context,
+    ) -> bool {
         match options.display {
             QuatDisplay::Raw => {
                 let mut vec4 = Vec4::from(*self);
@@ -135,7 +140,10 @@ fn from_euler_angles(val: Vec3) -> Quat {
 fn yaw_pitch_roll(q: Quat) -> (f32, f32, f32) {
     let [x, y, z, w] = *q.as_ref();
 
-    fn atan2(a: f32, b: f32) -> f32 {
+    fn atan2(
+        a: f32,
+        b: f32,
+    ) -> f32 {
         a.atan2(b)
     }
     fn asin(a: f32) -> f32 {

--- a/src/impls/rapier/nalgebra_impls.rs
+++ b/src/impls/rapier/nalgebra_impls.rs
@@ -86,7 +86,12 @@ impl Inspectable for Unit<Quaternion<f32>> {
 impl Inspectable for Unit<Complex<f32>> {
     type Attributes = ();
 
-    fn ui(&mut self, ui: &mut egui::Ui, _: Self::Attributes, _: &crate::Context) -> bool {
+    fn ui(
+        &mut self,
+        ui: &mut egui::Ui,
+        _: Self::Attributes,
+        _: &crate::Context,
+    ) -> bool {
         let mut angle = self.angle();
         let changed = ui.drag_angle_tau(&mut angle).changed();
         if changed {

--- a/src/impls/rapier/rapier2d_impls.rs
+++ b/src/impls/rapier/rapier2d_impls.rs
@@ -114,7 +114,12 @@ impl Inspectable for MassProperties {
 impl Inspectable for RigidBodyHandle {
     type Attributes = ();
 
-    fn ui(&mut self, ui: &mut bevy_egui::egui::Ui, _: Self::Attributes, _: &Context) -> bool {
+    fn ui(
+        &mut self,
+        ui: &mut bevy_egui::egui::Ui,
+        _: Self::Attributes,
+        _: &Context,
+    ) -> bool {
         let entity = self.entity();
         ui.label(format!("{:?}", entity));
         false
@@ -124,7 +129,12 @@ impl Inspectable for RigidBodyHandle {
 impl Inspectable for ColliderHandle {
     type Attributes = ();
 
-    fn ui(&mut self, ui: &mut bevy_egui::egui::Ui, _: Self::Attributes, _: &Context) -> bool {
+    fn ui(
+        &mut self,
+        ui: &mut bevy_egui::egui::Ui,
+        _: Self::Attributes,
+        _: &Context,
+    ) -> bool {
         let entity = self.entity();
         ui.label(format!("{:?}", entity));
         false
@@ -134,7 +144,12 @@ impl Inspectable for ColliderHandle {
 impl Inspectable for SharedShape {
     type Attributes = ();
 
-    fn ui(&mut self, ui: &mut egui::Ui, _: Self::Attributes, _: &Context) -> bool {
+    fn ui(
+        &mut self,
+        ui: &mut egui::Ui,
+        _: Self::Attributes,
+        _: &Context,
+    ) -> bool {
         #[rustfmt::skip]
         let shape = if self.0.is::<Ball>() { "Ball" }
         else if self.0.is::<HalfSpace>() { "HalfSpace" }
@@ -154,7 +169,12 @@ impl Inspectable for SharedShape {
 impl Inspectable for RigidBodyColliders {
     type Attributes = ();
 
-    fn ui(&mut self, ui: &mut egui::Ui, _: Self::Attributes, _: &Context) -> bool {
+    fn ui(
+        &mut self,
+        ui: &mut egui::Ui,
+        _: Self::Attributes,
+        _: &Context,
+    ) -> bool {
         ui.horizontal(|ui| {
             for (i, handle) in self.0.iter().enumerate() {
                 if i == self.0.len() - 1 {
@@ -171,7 +191,12 @@ impl Inspectable for RigidBodyColliders {
 impl Inspectable for ColliderMassProps {
     type Attributes = ();
 
-    fn ui(&mut self, ui: &mut egui::Ui, _: Self::Attributes, context: &Context) -> bool {
+    fn ui(
+        &mut self,
+        ui: &mut egui::Ui,
+        _: Self::Attributes,
+        context: &Context,
+    ) -> bool {
         match self {
             ColliderMassProps::Density(density) => {
                 ui.label("Density: ");

--- a/src/impls/rapier/rapier_impls.rs
+++ b/src/impls/rapier/rapier_impls.rs
@@ -114,7 +114,12 @@ impl Inspectable for MassProperties {
 impl Inspectable for RigidBodyHandle {
     type Attributes = ();
 
-    fn ui(&mut self, ui: &mut bevy_egui::egui::Ui, _: Self::Attributes, _: &Context) -> bool {
+    fn ui(
+        &mut self,
+        ui: &mut bevy_egui::egui::Ui,
+        _: Self::Attributes,
+        _: &Context,
+    ) -> bool {
         let entity = self.entity();
         ui.label(format!("{:?}", entity));
         false
@@ -124,7 +129,12 @@ impl Inspectable for RigidBodyHandle {
 impl Inspectable for ColliderHandle {
     type Attributes = ();
 
-    fn ui(&mut self, ui: &mut bevy_egui::egui::Ui, _: Self::Attributes, _: &Context) -> bool {
+    fn ui(
+        &mut self,
+        ui: &mut bevy_egui::egui::Ui,
+        _: Self::Attributes,
+        _: &Context,
+    ) -> bool {
         let entity = self.entity();
         ui.label(format!("{:?}", entity));
         false
@@ -134,7 +144,12 @@ impl Inspectable for ColliderHandle {
 impl Inspectable for SharedShape {
     type Attributes = ();
 
-    fn ui(&mut self, ui: &mut egui::Ui, _: Self::Attributes, _: &Context) -> bool {
+    fn ui(
+        &mut self,
+        ui: &mut egui::Ui,
+        _: Self::Attributes,
+        _: &Context,
+    ) -> bool {
         #[rustfmt::skip]
         let shape = if self.0.is::<Ball>() { "Ball" }
         else if self.0.is::<HalfSpace>() { "HalfSpace" }
@@ -157,7 +172,12 @@ impl Inspectable for SharedShape {
 impl Inspectable for RigidBodyColliders {
     type Attributes = ();
 
-    fn ui(&mut self, ui: &mut egui::Ui, _: Self::Attributes, _: &Context) -> bool {
+    fn ui(
+        &mut self,
+        ui: &mut egui::Ui,
+        _: Self::Attributes,
+        _: &Context,
+    ) -> bool {
         ui.horizontal(|ui| {
             for (i, handle) in self.0.iter().enumerate() {
                 if i == self.0.len() - 1 {
@@ -174,7 +194,12 @@ impl Inspectable for RigidBodyColliders {
 impl Inspectable for ColliderMassProps {
     type Attributes = ();
 
-    fn ui(&mut self, ui: &mut egui::Ui, _: Self::Attributes, context: &Context) -> bool {
+    fn ui(
+        &mut self,
+        ui: &mut egui::Ui,
+        _: Self::Attributes,
+        context: &Context,
+    ) -> bool {
         match self {
             ColliderMassProps::Density(density) => {
                 ui.label("Density: ");

--- a/src/impls/vec.rs
+++ b/src/impls/vec.rs
@@ -61,7 +61,11 @@ impl Inspectable for Vec2 {
     }
 }
 
-fn point_select(value: &mut Vec2, ui: &mut egui::Ui, options: Vec2dAttributes) -> bool {
+fn point_select(
+    value: &mut Vec2,
+    ui: &mut egui::Ui,
+    options: Vec2dAttributes,
+) -> bool {
     let range = match (options.min, options.max) {
         (Some(min), Some(max)) => min..=max,
         (Some(min), None) => min..=Vec2::splat(0.0),
@@ -87,7 +91,11 @@ struct PointSelect<'a> {
     value: &'a mut Vec2,
 }
 impl<'a> PointSelect<'a> {
-    fn new(value: &'a mut Vec2, range: RangeInclusive<Vec2>, size: f32) -> Self {
+    fn new(
+        value: &'a mut Vec2,
+        range: RangeInclusive<Vec2>,
+        size: f32,
+    ) -> Self {
         PointSelect {
             value,
             range,
@@ -103,12 +111,19 @@ impl<'a> PointSelect<'a> {
         self.range.end().y..=self.range.start().y
     }
 
-    fn value_to_ui_pos(&self, rect: &Rect) -> Pos2 {
+    fn value_to_ui_pos(
+        &self,
+        rect: &Rect,
+    ) -> Pos2 {
         let x = egui::remap_clamp(self.value.x, self.x_range(), rect.x_range());
         let y = egui::remap_clamp(self.value.y, self.y_range(), rect.y_range());
         Pos2::new(x, y)
     }
-    fn ui_pos_to_value(&self, rect: &Rect, pos: Pos2) -> Vec2 {
+    fn ui_pos_to_value(
+        &self,
+        rect: &Rect,
+        pos: Pos2,
+    ) -> Vec2 {
         let x = egui::remap_clamp(pos.x, rect.x_range(), self.x_range());
         let y = egui::remap_clamp(pos.y, rect.y_range(), self.y_range());
 
@@ -117,7 +132,10 @@ impl<'a> PointSelect<'a> {
 }
 
 impl Widget for PointSelect<'_> {
-    fn ui(self, ui: &mut egui::Ui) -> egui::Response {
+    fn ui(
+        self,
+        ui: &mut egui::Ui,
+    ) -> egui::Response {
         let (rect, mut response) = ui.allocate_exact_size(self.size, Sense::click_and_drag());
         let painter = ui.painter();
 
@@ -150,7 +168,12 @@ impl Widget for PointSelect<'_> {
 impl Inspectable for Vec3 {
     type Attributes = NumberAttributes<Vec3>;
 
-    fn ui(&mut self, ui: &mut egui::Ui, options: Self::Attributes, context: &Context) -> bool {
+    fn ui(
+        &mut self,
+        ui: &mut egui::Ui,
+        options: Self::Attributes,
+        context: &Context,
+    ) -> bool {
         let mut changed = false;
         ui.scope(|ui| {
             ui.style_mut().spacing.item_spacing = egui::Vec2::new(4.0, 0.);
@@ -168,7 +191,12 @@ impl Inspectable for Vec3 {
 impl Inspectable for Vec4 {
     type Attributes = NumberAttributes<Vec4>;
 
-    fn ui(&mut self, ui: &mut egui::Ui, options: Self::Attributes, context: &Context) -> bool {
+    fn ui(
+        &mut self,
+        ui: &mut egui::Ui,
+        options: Self::Attributes,
+        context: &Context,
+    ) -> bool {
         let mut changed = false;
         ui.scope(|ui| {
             ui.style_mut().spacing.item_spacing = egui::Vec2::new(4.0, 0.);

--- a/src/impls/with_context.rs
+++ b/src/impls/with_context.rs
@@ -33,7 +33,12 @@ macro_rules! expect_handle {
 impl Inspectable for HandleId {
     type Attributes = ();
 
-    fn ui(&mut self, ui: &mut egui::Ui, _: Self::Attributes, _: &Context) -> bool {
+    fn ui(
+        &mut self,
+        ui: &mut egui::Ui,
+        _: Self::Attributes,
+        _: &Context,
+    ) -> bool {
         ui.label("<handle id>");
         false
     }
@@ -42,7 +47,12 @@ impl Inspectable for HandleId {
 impl<T: Asset + Inspectable> Inspectable for Handle<T> {
     type Attributes = T::Attributes;
 
-    fn ui(&mut self, ui: &mut egui::Ui, options: Self::Attributes, context: &Context) -> bool {
+    fn ui(
+        &mut self,
+        ui: &mut egui::Ui,
+        options: Self::Attributes,
+        context: &Context,
+    ) -> bool {
         if self.id == HandleId::default::<T>() {
             ui.label("<default handle>");
             return false;
@@ -80,7 +90,12 @@ impl Default for TextureAttributes {
 impl Inspectable for Handle<Texture> {
     type Attributes = TextureAttributes;
 
-    fn ui(&mut self, ui: &mut egui::Ui, options: Self::Attributes, context: &Context) -> bool {
+    fn ui(
+        &mut self,
+        ui: &mut egui::Ui,
+        options: Self::Attributes,
+        context: &Context,
+    ) -> bool {
         let world = expect_world!(ui, context, "Handle<Texture>");
         let _ = world.get_resource_or_insert_with(ScaledDownTextures::default);
 
@@ -153,7 +168,12 @@ fn rescaled_image<'a>(
 impl Inspectable for Handle<Font> {
     type Attributes = ();
 
-    fn ui(&mut self, ui: &mut egui::Ui, _: Self::Attributes, context: &Context) -> bool {
+    fn ui(
+        &mut self,
+        ui: &mut egui::Ui,
+        _: Self::Attributes,
+        context: &Context,
+    ) -> bool {
         let world = expect_world!(ui, context, "Handle<Texture>");
         let asset_server = world.get_resource::<AssetServer>().unwrap();
         let file_events = world.get_resource::<Events<FileDragAndDrop>>().unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,7 +120,10 @@ impl<'a> Context<'a> {
 
 impl<'a> Context<'a> {
     /// Create new context with exclusive access to the `World`
-    pub fn new(ui_ctx: &'a CtxRef, world: &'a mut World) -> Self {
+    pub fn new(
+        ui_ctx: &'a CtxRef,
+        world: &'a mut World,
+    ) -> Self {
         Context {
             ui_ctx: Some(ui_ctx),
             world: Some(world as *mut _),
@@ -131,7 +134,10 @@ impl<'a> Context<'a> {
     /// # Safety
     /// The `world` pointer must come from a mutable reference to a world and no
     /// other threads must be writing to it.
-    pub unsafe fn new_ptr(ui_ctx: Option<&'a CtxRef>, world: *mut World) -> Self {
+    pub unsafe fn new_ptr(
+        ui_ctx: Option<&'a CtxRef>,
+        world: *mut World,
+    ) -> Self {
         Context {
             ui_ctx,
             world: Some(world),
@@ -149,7 +155,10 @@ impl<'a> Context<'a> {
     }
 
     /// Same context but with a specified `id`
-    pub fn with_id(&self, id: u64) -> Self {
+    pub fn with_id(
+        &self,
+        id: u64,
+    ) -> Self {
         let mut hasher = std::collections::hash_map::DefaultHasher::default();
         if let Some(id) = self.id {
             hasher.write_u64(id);
@@ -213,11 +222,20 @@ pub trait Inspectable {
 
     /// This methods is responsible for building the egui ui.
     /// Returns whether any data was modified.
-    fn ui(&mut self, ui: &mut egui::Ui, options: Self::Attributes, context: &Context) -> bool;
+    fn ui(
+        &mut self,
+        ui: &mut egui::Ui,
+        options: Self::Attributes,
+        context: &Context,
+    ) -> bool;
 
     /// Displays the value without any context. Useful for usage outside of the plugins, where
     /// there is no access to the world or [`EguiContext`](bevy_egui::EguiContext).
-    fn ui_raw(&mut self, ui: &mut egui::Ui, options: Self::Attributes) {
+    fn ui_raw(
+        &mut self,
+        ui: &mut egui::Ui,
+        options: Self::Attributes,
+    ) {
         let empty_context = Context::new_shared(None);
         self.ui(ui, options, &empty_context);
     }

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -55,7 +55,10 @@ impl<T> InspectorPlugin<T> {
     }
 
     /// Sets the window the inspector should be displayed on
-    pub fn on_window(self, window_id: WindowId) -> Self {
+    pub fn on_window(
+        self,
+        window_id: WindowId,
+    ) -> Self {
         InspectorPlugin { window_id, ..self }
     }
 }
@@ -63,13 +66,23 @@ impl<T> InspectorPlugin<T> {
 #[derive(Default, Debug)]
 struct InspectorWindows(bevy::utils::HashMap<TypeId, (String, WindowId)>);
 impl InspectorWindows {
-    fn insert<T: 'static>(&mut self, name: String, window_id: WindowId) {
+    fn insert<T: 'static>(
+        &mut self,
+        name: String,
+        window_id: WindowId,
+    ) {
         self.0.insert(TypeId::of::<T>(), (name, window_id));
     }
-    fn contains_id(&self, type_id: TypeId) -> bool {
+    fn contains_id(
+        &self,
+        type_id: TypeId,
+    ) -> bool {
         self.0.iter().any(|(&id, _)| id == type_id)
     }
-    fn contains_name(&self, name: &str) -> bool {
+    fn contains_name(
+        &self,
+        name: &str,
+    ) -> bool {
         self.0.iter().any(|(_, (n, _))| n == name)
     }
     fn get_unwrap<T: 'static>(&self) -> &(String, WindowId) {
@@ -94,7 +107,10 @@ impl<T> Plugin for InspectorPlugin<T>
 where
     T: Inspectable + Send + Sync + 'static,
 {
-    fn build(&self, app: &mut AppBuilder) {
+    fn build(
+        &self,
+        app: &mut AppBuilder,
+    ) {
         if let Some(get_value) = &self.initial_value {
             let world = app.world_mut();
             let resource = get_value(world);

--- a/src/reflect/mod.rs
+++ b/src/reflect/mod.rs
@@ -58,7 +58,12 @@ impl<T> DerefMut for ReflectedUI<T> {
 impl<T: Reflect> Inspectable for ReflectedUI<T> {
     type Attributes = ();
 
-    fn ui(&mut self, ui: &mut egui::Ui, _: Self::Attributes, context: &Context) -> bool {
+    fn ui(
+        &mut self,
+        ui: &mut egui::Ui,
+        _: Self::Attributes,
+        context: &Context,
+    ) -> bool {
         ui_for_reflect(&mut self.0, ui, context)
     }
 }
@@ -79,7 +84,11 @@ macro_rules! try_downcast_ui {
 ///
 /// This function gets used for the implementation of [`Inspectable`](crate::Inspectable)
 /// for [`ReflectedUI`](ReflectedUI).
-pub fn ui_for_reflect(value: &mut dyn Reflect, ui: &mut egui::Ui, context: &Context) -> bool {
+pub fn ui_for_reflect(
+    value: &mut dyn Reflect,
+    ui: &mut egui::Ui,
+    context: &Context,
+) -> bool {
     if let Some(world) = unsafe { context.world() } {
         if let Some(inspect_registry) = world.get_resource::<InspectableRegistry>() {
             if let Ok(changed) = inspect_registry.try_execute(value, ui, context) {
@@ -98,7 +107,11 @@ pub fn ui_for_reflect(value: &mut dyn Reflect, ui: &mut egui::Ui, context: &Cont
     }
 }
 
-fn ui_for_reflect_struct(value: &mut dyn Struct, ui: &mut egui::Ui, context: &Context) -> bool {
+fn ui_for_reflect_struct(
+    value: &mut dyn Struct,
+    ui: &mut egui::Ui,
+    context: &Context,
+) -> bool {
     let mut changed = false;
     ui.vertical_centered(|ui| {
         let grid = Grid::new(value.type_id());
@@ -120,7 +133,11 @@ fn ui_for_reflect_struct(value: &mut dyn Struct, ui: &mut egui::Ui, context: &Co
     changed
 }
 
-fn ui_for_tuple_struct(value: &mut dyn TupleStruct, ui: &mut egui::Ui, context: &Context) -> bool {
+fn ui_for_tuple_struct(
+    value: &mut dyn TupleStruct,
+    ui: &mut egui::Ui,
+    context: &Context,
+) -> bool {
     let mut changed = false;
     let grid = Grid::new(value.type_id());
     grid.show(ui, |ui| {
@@ -137,7 +154,11 @@ fn ui_for_tuple_struct(value: &mut dyn TupleStruct, ui: &mut egui::Ui, context: 
     changed
 }
 
-fn ui_for_tuple(value: &mut dyn Tuple, ui: &mut egui::Ui, context: &Context) -> bool {
+fn ui_for_tuple(
+    value: &mut dyn Tuple,
+    ui: &mut egui::Ui,
+    context: &Context,
+) -> bool {
     let mut changed = false;
     let grid = Grid::new(value.type_id());
     grid.show(ui, |ui| {
@@ -154,7 +175,11 @@ fn ui_for_tuple(value: &mut dyn Tuple, ui: &mut egui::Ui, context: &Context) -> 
     changed
 }
 
-fn ui_for_list(list: &mut dyn List, ui: &mut egui::Ui, context: &Context) -> bool {
+fn ui_for_list(
+    list: &mut dyn List,
+    ui: &mut egui::Ui,
+    context: &Context,
+) -> bool {
     let mut changed = false;
 
     ui.vertical(|ui| {
@@ -194,12 +219,19 @@ fn ui_for_list(list: &mut dyn List, ui: &mut egui::Ui, context: &Context) -> boo
     changed
 }
 
-fn ui_for_map(_value: &mut dyn Map, ui: &mut egui::Ui) -> bool {
+fn ui_for_map(
+    _value: &mut dyn Map,
+    ui: &mut egui::Ui,
+) -> bool {
     ui.label("Map not yet implemented");
     false
 }
 
-fn ui_for_reflect_value(value: &mut dyn Reflect, ui: &mut egui::Ui, context: &Context) -> bool {
+fn ui_for_reflect_value(
+    value: &mut dyn Reflect,
+    ui: &mut egui::Ui,
+    context: &Context,
+) -> bool {
     try_downcast_ui!(
         value ui context =>
         f32, f64, u8, u16, u32, u64, i8, i16, i32, i64,

--- a/src/utils/macros.rs
+++ b/src/utils/macros.rs
@@ -97,7 +97,12 @@ macro_rules! impl_defer_to {
         impl $crate::Inspectable for $ty {
             type Attributes = ();
 
-            fn ui(&mut self, ui: &mut egui::Ui, (): Self::Attributes, context: &Context) -> bool {
+            fn ui(
+                &mut self,
+                ui: &mut egui::Ui,
+                (): Self::Attributes,
+                context: &Context,
+            ) -> bool {
                 self.$inner.ui(ui, Default::default(), context)
             }
         }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -11,7 +11,10 @@ use egui::{Color32, Label};
 
 const ERROR_COLOR: Color32 = Color32::from_rgb(255, 0, 0);
 
-pub(crate) fn error_label(ui: &mut egui::Ui, msg: impl Into<Label>) {
+pub(crate) fn error_label(
+    ui: &mut egui::Ui,
+    msg: impl Into<Label>,
+) {
     ui.colored_label(ERROR_COLOR, msg);
 }
 

--- a/src/utils/sort_if.rs
+++ b/src/utils/sort_if.rs
@@ -2,7 +2,11 @@
 /// This avoids collecting the iterator
 /// if it shouldn't be sorted.
 // Overenginereed? Yes. Had fun implementing? Also yes.
-pub fn sort_iter_if<T, I, F>(iter: I, sort: bool, compare: F) -> impl Iterator<Item = T>
+pub fn sort_iter_if<T, I, F>(
+    iter: I,
+    sort: bool,
+    compare: F,
+) -> impl Iterator<Item = T>
 where
     I: Iterator<Item = T>,
     F: Fn(&T, &T) -> std::cmp::Ordering,

--- a/src/utils/ui.rs
+++ b/src/utils/ui.rs
@@ -8,7 +8,10 @@ use bevy_egui::egui::{self, Label, Response};
 pub fn drag_and_drop_target(ui: &mut egui::Ui) -> Response {
     drag_and_drop_target_label(ui, "Drag file here")
 }
-pub fn drag_and_drop_target_label(ui: &mut egui::Ui, label: impl Into<Label>) -> Response {
+pub fn drag_and_drop_target_label(
+    ui: &mut egui::Ui,
+    label: impl Into<Label>,
+) -> Response {
     let frame = egui::containers::Frame::dark_canvas(&ui.style());
     frame.show(ui, |ui| ui.label(label)).inner
 }
@@ -30,7 +33,11 @@ pub fn replace_handle_if_dropped<T: Asset>(
     false
 }
 
-pub fn label_button(ui: &mut egui::Ui, text: &str, text_color: egui::Color32) -> bool {
+pub fn label_button(
+    ui: &mut egui::Ui,
+    text: &str,
+    text_color: egui::Color32,
+) -> bool {
     ui.add(egui::Button::new(text).text_color(text_color).frame(false))
         .clicked()
 }

--- a/src/widgets/button.rs
+++ b/src/widgets/button.rs
@@ -29,7 +29,10 @@ impl<E> InspectableButton<E> {
 }
 
 impl<E> std::fmt::Debug for InspectableButton<E> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(
+        &self,
+        f: &mut std::fmt::Formatter<'_>,
+    ) -> std::fmt::Result {
         f.debug_struct("InspectableButton").finish()
     }
 }

--- a/src/widgets/new_window.rs
+++ b/src/widgets/new_window.rs
@@ -61,7 +61,12 @@ impl<T> DerefMut for InNewWindow<T> {
 impl<T: Inspectable + 'static> Inspectable for InNewWindow<T> {
     type Attributes = WindowAttributes<T>;
 
-    fn ui(&mut self, ui: &mut egui::Ui, options: Self::Attributes, context: &Context) -> bool {
+    fn ui(
+        &mut self,
+        ui: &mut egui::Ui,
+        options: Self::Attributes,
+        context: &Context,
+    ) -> bool {
         let ui_ctx = match context.ui_ctx {
             Some(ctx) => ctx,
             None => {

--- a/src/widgets/resource_inspector.rs
+++ b/src/widgets/resource_inspector.rs
@@ -40,7 +40,10 @@ impl<T: Inspectable + Send + Sync + 'static> Inspectable for ResourceInspector<T
 }
 
 impl<T> std::fmt::Debug for ResourceInspector<T> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(
+        &self,
+        f: &mut std::fmt::Formatter<'_>,
+    ) -> std::fmt::Result {
         f.debug_struct("ResourceInspector").finish()
     }
 }

--- a/src/world_inspector/inspectable_registry.rs
+++ b/src/world_inspector/inspectable_registry.rs
@@ -29,8 +29,10 @@ impl InspectableRegistry {
     }
 
     /// Registers a type that doesn't need to implement [`Inspectable`](crate::Inspectable)
-    pub fn register_raw<T: 'static, F>(&mut self, f: F)
-    where
+    pub fn register_raw<T: 'static, F>(
+        &mut self,
+        f: F,
+    ) where
         F: Fn(&mut T, &mut egui::Ui, &Context) -> bool + Send + Sync + 'static,
     {
         let type_id = TypeId::of::<T>();

--- a/src/world_inspector/mod.rs
+++ b/src/world_inspector/mod.rs
@@ -64,11 +64,17 @@ impl WorldInspectorParams {
         self.ignore_components.insert(TypeId::of::<T>());
     }
 
-    fn should_ignore_component(&self, type_id: TypeId) -> bool {
+    fn should_ignore_component(
+        &self,
+        type_id: TypeId,
+    ) -> bool {
         self.ignore_components.contains(&type_id)
     }
 
-    fn is_read_only(&self, type_id: TypeId) -> bool {
+    fn is_read_only(
+        &self,
+        type_id: TypeId,
+    ) -> bool {
         self.read_only_components.contains(&type_id)
     }
 
@@ -126,7 +132,10 @@ struct WorldUIContext<'a> {
     delete_entity: Cell<Option<Entity>>,
 }
 impl<'a> WorldUIContext<'a> {
-    fn new(ui_ctx: Option<&'a egui::CtxRef>, world: &'a mut World) -> WorldUIContext<'a> {
+    fn new(
+        ui_ctx: Option<&'a egui::CtxRef>,
+        world: &'a mut World,
+    ) -> WorldUIContext<'a> {
         WorldUIContext {
             world,
             ui_ctx,
@@ -144,14 +153,21 @@ impl Drop for WorldUIContext<'_> {
 }
 
 impl<'a> WorldUIContext<'a> {
-    fn entity_name(&self, entity: Entity) -> Cow<'_, str> {
+    fn entity_name(
+        &self,
+        entity: Entity,
+    ) -> Cow<'_, str> {
         match self.world.get_entity(entity) {
             Some(entity) => guess_entity_name(entity),
             None => format!("Entity {} (inexistent)", entity.id()).into(),
         }
     }
 
-    fn world_ui<F>(&mut self, ui: &mut egui::Ui, params: &WorldInspectorParams) -> bool
+    fn world_ui<F>(
+        &mut self,
+        ui: &mut egui::Ui,
+        params: &WorldInspectorParams,
+    ) -> bool
     where
         F: WorldQuery,
         F::Fetch: FilterFetch,

--- a/src/world_inspector/plugin.rs
+++ b/src/world_inspector/plugin.rs
@@ -91,7 +91,10 @@ where
     F: WorldQuery + 'static,
     F::Fetch: FilterFetch,
 {
-    fn build(&self, app: &mut AppBuilder) {
+    fn build(
+        &self,
+        app: &mut AppBuilder,
+    ) {
         if !app.world_mut().contains_resource::<EguiContext>() {
             app.add_plugin(EguiPlugin);
         }


### PR DESCRIPTION
Hey,
Loving the inspector.

This wasn't obvious for me as a first time user, and would seems to be a fairly common use case. Hopefully it helps someone else..

VecAsDropdown works over a Vec of
    T: Clone + Display + PartialEq + Debug + Default,

from the code:
```
impl<T> Inspectable for VecAsDropdown<T>
where
    T: Clone + Display + PartialEq + Debug + Default,
{
    type Attributes = Vec<T>;
```

Thanks!