### PR TITLE
Upgrade to bevy_egui 0.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ nightly = []
 bevy = { version = "0.6", default-features = false, features = [
     "bevy_render", "bevy_pbr", "bevy_sprite", "bevy_text", "bevy_ui"
 ] }
-bevy_egui = { version = "0.11.1", default-features = false, features = ["open_url"] }
+bevy_egui = { version = "0.12.0", default-features = false, features = ["open_url"] }
 pretty-type-name = "1.0"
 image = { version = "0.23", default-features = false }
 nalgebra030 = { package = "nalgebra", version = "0.30", optional = true }

--- a/src/impls/vec.rs
+++ b/src/impls/vec.rs
@@ -77,7 +77,7 @@ fn point_select(value: &mut Vec2, ui: &mut egui::Ui, options: Vec2dAttributes) -
     };
 
     let mut frame = containers::Frame::dark_canvas(ui.style());
-    frame.margin = egui::Vec2::ZERO;
+    frame.margin = egui::Vec2::ZERO.into();
 
     frame
         .show(ui, |ui| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,7 +115,6 @@ use std::marker::PhantomData;
 
 use bevy::ecs::system::Resource;
 use bevy::prelude::{App, Mut, World};
-use egui::CtxRef;
 use utils::error_label_needs_world;
 #[doc(inline)]
 pub use world_inspector::{InspectableRegistry, WorldInspectorParams, WorldInspectorPlugin};
@@ -142,7 +141,7 @@ pub mod options {
 /// The context passed to [`Inspectable::ui`].
 pub struct Context<'a> {
     /// egui ui context
-    pub ui_ctx: Option<&'a CtxRef>,
+    pub ui_ctx: Option<&'a egui::Context>,
     /// The world is only available when not using `InspectablePlugin::shared()`
     world: Option<*mut World>,
     _world_marker: PhantomData<&'a mut ()>,
@@ -250,7 +249,7 @@ impl<'a> Context<'a> {
 
 impl<'a> Context<'a> {
     /// Create a new context with access to the world
-    pub fn new_world_access(ui_ctx: Option<&'a CtxRef>, world: &'a mut World) -> Self {
+    pub fn new_world_access(ui_ctx: Option<&'a egui::Context>, world: &'a mut World) -> Self {
         Context {
             ui_ctx,
             world: Some(world),
@@ -260,7 +259,7 @@ impl<'a> Context<'a> {
     }
 
     /// Creates a context without access to `World`
-    pub fn new_shared(ui_ctx: Option<&'a CtxRef>) -> Self {
+    pub fn new_shared(ui_ctx: Option<&'a egui::Context>) -> Self {
         Context {
             ui_ctx,
             world: None,


### PR DESCRIPTION
There are two notable changes:
- As `bevy_egui` tracks ids of user textures itself, I removed `id_of_handle` and updated the relevant code.
- I had to remove the `layout_job` macro (now it's just a function), as `TextFormat` uses `FontId` instead of `TextStyle`, which can't be constructed just with an `ident`.

The changes compile, but I haven't tested them very extensively.