### PR TITLE
Prevent `Duration` loss of precision

### DIFF
--- a/src/impls/std.rs
+++ b/src/impls/std.rs
@@ -142,7 +142,7 @@ impl Inspectable for Duration {
     type Attributes = ();
 
     fn ui(&mut self, ui: &mut egui::Ui, _: Self::Attributes, context: &mut Context) -> bool {
-        let mut seconds = self.as_secs_f32();
+        let mut seconds = self.as_secs_f64();
         let attributes = NumberAttributes {
             min: Some(0.0),
             suffix: "s".to_string(),
@@ -150,7 +150,7 @@ impl Inspectable for Duration {
         };
         let changed = seconds.ui(ui, attributes, context);
         if changed { // floating point conversion is lossy
-            *self = Duration::from_secs_f32(seconds);
+            *self = Duration::from_secs_f64(seconds);
         }
         changed
     }

--- a/src/impls/std.rs
+++ b/src/impls/std.rs
@@ -149,7 +149,9 @@ impl Inspectable for Duration {
             ..Default::default()
         };
         let changed = seconds.ui(ui, attributes, context);
-        *self = Duration::from_secs_f32(seconds);
+        if changed { // floating point conversion is lossy
+            *self = Duration::from_secs_f32(seconds);
+        }
         changed
     }
 }


### PR DESCRIPTION
Currently any `Duration` that's in an `Inspectable` struct (like a `Component` or `Resource`) gets rounded off to the closest f32 seconds representation every frame. This breaks logic that adds small `Duration` values with large ones. For example, in my game I have an `age` field in a resource that can increase to very large amounts (years) when fast-forwarding but then need to increase by small amounts (milliseconds) when going in slow-motion. Without this fix, the `age` field never increases because `bevy-inspector-egui` rounds it off.

I'm not sure if `f64` is able to capture enough precision to prevent this corner case, but either way it seems that any lossy or imprecise conversion should only set the value when changed manually by the user.