### PR TITLE
Change Val::px and Val::Percent to no longer be clamped

### DIFF
--- a/src/impls/bevy_ui.rs
+++ b/src/impls/bevy_ui.rs
@@ -162,7 +162,6 @@ impl Inspectable for Val {
                     };
 
                     let attrs = NumberAttributes {
-                        min: Some(0.0),
                         speed: 10.0,
                         ..Default::default()
                     };
@@ -175,12 +174,7 @@ impl Inspectable for Val {
                         _ => 0.0,
                     };
 
-                    let attrs = NumberAttributes {
-                        min: Some(0.0),
-                        max: Some(100.0),
-                        ..Default::default()
-                    };
-                    changed |= value.ui(&mut ui[1], attrs, context);
+                    changed |= value.ui(&mut ui[1], Default::default(), context);
                     *self = Val::Percent(value);
                 }
                 None => {}


### PR DESCRIPTION
## Description
This removes the min and max from the Inspectable implementation for Val::Px and Val:Percent

## Reasoning
Being able to enter negative values is extremely valuable for working with UI and this was preventing using the inspector without breaking things if you have negative or out of "normal" bounds values.

It's not desirable to have simply viewing a node in the inspector make changes to the node (Could cause or even prevent bugs when having the node open in the inspector), so we should strive to only enforce the limits that are imposed by Bevy's types unless we have a way to do so only when the user makes a change using in the inspector (Might be worthy of a feature request to egui? Currently not sure if it's possible.).

P.S.
Thanks again for this plugin, it's been extremely helpful with my latest project. Let me know if you want any changes to this PR etc.