### PR TITLE
Update bevy_rapier to 0.14

### DIFF
--- a/integrations/bevy-inspector-egui-rapier/Cargo.toml
+++ b/integrations/bevy-inspector-egui-rapier/Cargo.toml
@@ -16,8 +16,8 @@ rapier2d = ["bevy_rapier2d"]
 
 [dependencies]
 bevy-inspector-egui = { version = "0.11", path = "../..", features = ["nalgebra031"] }
-bevy_rapier3d = { version = "0.13.0", optional = true }
-bevy_rapier2d = { version = "0.13.0", optional = true }
+bevy_rapier3d = { version = "0.14", optional = true }
+bevy_rapier2d = { version = "0.14", optional = true }
 bevy = { version = "0.7", default-features = false }
 
 [dev-dependencies]


### PR DESCRIPTION
It doesn't seem like there are any breaking changes affecting `bevy-inspector-egui`, so the update is pretty trivial.