### PR TITLE
Marker sensor/bump bevy_rapier to 0.15

### DIFF
--- a/integrations/bevy-inspector-egui-rapier/Cargo.toml
+++ b/integrations/bevy-inspector-egui-rapier/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy-inspector-egui-rapier"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 repository = "https://github.com/jakobhellermann/bevy-inspector-egui/"
 

--- a/integrations/bevy-inspector-egui-rapier/README.md
+++ b/integrations/bevy-inspector-egui-rapier/README.md
@@ -25,8 +25,9 @@ fn main() {
 
 ## Bevy support table
 
-| bevy    | bevy-inspector-egui | bevy-inspector-egui-rapier | bevy_rapier
+| bevy    | bevy-inspector-egui | bevy-inspector-egui-rapier | bevy\_rapier
 | ------- | ------------------- | -------------------------- | ------
+| 0.7     | 0.11                | 0.4                        | 0.14
 | 0.7     | 0.11                | 0.3                        | 0.13
 | 0.7     | 0.10                | 0.2                        | 0.12
 | 0.6     | 0.9                 | 0.1                        | 0.12

--- a/integrations/bevy-inspector-egui-rapier/src/macros.rs
+++ b/integrations/bevy-inspector-egui-rapier/src/macros.rs
@@ -110,7 +110,12 @@ macro_rules! inspectable {
         fn $name(val: &mut $ty, ui: &mut egui::Ui, context: &mut Context<'_>) -> bool {
             val.$val.ui(ui, Default::default(), context)
         }
-    }
+    };
+    (marker $name:ident $ty:ty) => {
+        fn $name(val: &mut $ty, ui: &mut egui::Ui, context: &mut Context<'_>) -> bool {
+            val.ui(ui, Default::default(), context)
+        }
+    };
 }
 
 pub(crate) use {enum_one, flags, grid, inspectable, simple_enum};

--- a/integrations/bevy-inspector-egui-rapier/src/macros.rs
+++ b/integrations/bevy-inspector-egui-rapier/src/macros.rs
@@ -113,7 +113,8 @@ macro_rules! inspectable {
     };
     (marker $name:ident $ty:ty) => {
         fn $name(val: &mut $ty, ui: &mut egui::Ui, context: &mut Context<'_>) -> bool {
-            val.ui(ui, Default::default(), context)
+            true
+            //val.ui(ui, Default::default(), context)
         }
     };
 }

--- a/integrations/bevy-inspector-egui-rapier/src/rapier_impl.rs
+++ b/integrations/bevy-inspector-egui-rapier/src/rapier_impl.rs
@@ -11,7 +11,7 @@ use bevy_rapier::prelude::*;
 
 inspectable!(defer ccd Ccd: enabled);
 inspectable!(defer gravity_scale GravityScale: 0);
-inspectable!(defer sensor Sensor);
+inspectable!(marker sensor Sensor);
 inspectable!(enum active_collision_types ActiveCollisionTypes: DYNAMIC_DYNAMIC|DYNAMIC_KINEMATIC|DYNAMIC_STATIC|KINEMATIC_KINEMATIC|KINEMATIC_STATIC|STATIC_STATIC);
 inspectable!(enum active_hooks ActiveHooks: FILTER_CONTACT_PAIRS|FILTER_INTERSECTION_PAIR|MODIFY_SOLVER_CONTACTS);
 inspectable!(enum coefficient_combine_rule CoefficientCombineRule: Average|Min|Multiply|Max);

--- a/integrations/bevy-inspector-egui-rapier/src/rapier_impl.rs
+++ b/integrations/bevy-inspector-egui-rapier/src/rapier_impl.rs
@@ -11,7 +11,7 @@ use bevy_rapier::prelude::*;
 
 inspectable!(defer ccd Ccd: enabled);
 inspectable!(defer gravity_scale GravityScale: 0);
-inspectable!(defer sensor Sensor: 0);
+inspectable!(defer sensor Sensor);
 inspectable!(enum active_collision_types ActiveCollisionTypes: DYNAMIC_DYNAMIC|DYNAMIC_KINEMATIC|DYNAMIC_STATIC|KINEMATIC_KINEMATIC|KINEMATIC_STATIC|STATIC_STATIC);
 inspectable!(enum active_hooks ActiveHooks: FILTER_CONTACT_PAIRS|FILTER_INTERSECTION_PAIR|MODIFY_SOLVER_CONTACTS);
 inspectable!(enum coefficient_combine_rule CoefficientCombineRule: Average|Min|Multiply|Max);


### PR DESCRIPTION
Need to figure out if there is a better way to just show a marker component here. But should fix any conflicts with the current version