### PR TITLE
Allow negative scale

### DIFF
--- a/src/impls/bevy_impls.rs
+++ b/src/impls/bevy_impls.rs
@@ -1,4 +1,3 @@
-use crate::options::NumberAttributes;
 use crate::{Context, Inspectable};
 use bevy::ecs::system::Resource;
 use bevy::prelude::*;
@@ -28,11 +27,7 @@ impl Inspectable for Transform {
                 ui.end_row();
 
                 ui.label("Scale");
-                let scale_attributes = NumberAttributes {
-                    min: Some(Vec3::splat(0.0)),
-                    ..Default::default()
-                };
-                changed |= self.scale.ui(ui, scale_attributes, context);
+                changed |= self.scale.ui(ui, Default::default(), context);
                 ui.end_row();
             });
         });


### PR DESCRIPTION
This was disallowed in c1ffc5d, but there is nothing invalid about a negative scale.

I have a scene using a SpatialBundle with a negative transform scale to flip a bunch of 2D meshes on the x-axis together, and the bounds check here was causing that scale to get reset to 0.0 when inspecting the entity.