### PR TITLE
added sprite Anchor to sprite inspector

### DIFF
--- a/src/impls/bevy_sprite.rs
+++ b/src/impls/bevy_sprite.rs
@@ -29,7 +29,21 @@ impl_for_simple_enum!(Anchor:
     TopLeft,
     TopCenter,
     TopRight:
-    Custom Anchor::Custom(_) => Vec2::default()
+    Custom Anchor::Custom(_) => Vec2::default();
+    if let Anchor::Custom(val) => |ui: &mut egui::Ui, context: &mut Context| {
+        let mut changed = false;
+        ui.horizontal(|ui| {
+            ui.label("x:");
+            let x_attrs = crate::options::NumberAttributes::default();
+            changed |= val.x.ui(ui, x_attrs, context);
+        });
+        ui.horizontal(|ui| {
+            ui.label("y:");
+            let y_attrs = crate::options::NumberAttributes::default();
+            changed |= val.y.ui(ui, y_attrs, context);
+        });
+        changed
+    }
 );
 
 impl_for_struct_delegate_fields!(bevy::sprite::Rect:
@@ -49,7 +63,6 @@ impl Inspectable for TextureAtlas {
                 .texture
                 .ui(ui, Default::default(), &mut context.with_id(0));
             ui.end_row();
-
             ui.label("size");
             changed |= self.size.ui(ui, Vec2dAttributes::integer(), context);
             ui.end_row();

--- a/src/impls/bevy_sprite.rs
+++ b/src/impls/bevy_sprite.rs
@@ -1,5 +1,6 @@
 use bevy::{
     prelude::*,
+    sprite::Anchor,
     render::mesh::{Indices, VertexAttributeValues},
     sprite::Mesh2dHandle,
 };
@@ -14,7 +15,21 @@ impl_for_struct_delegate_fields!(Sprite:
     color,
     flip_x,
     flip_y,
-    custom_size with OptionAttributes { replacement: Some(|| Vec2::splat(50.0)), deletable: true, inner: Vec2dAttributes::positive() }
+    custom_size with OptionAttributes { replacement: Some(|| Vec2::splat(50.0)), deletable: true, inner: Vec2dAttributes::positive() },
+    anchor
+);
+
+impl_for_simple_enum!(Anchor:
+    Center,
+    BottomLeft,
+    BottomCenter,
+    BottomRight,
+    CenterLeft,
+    CenterRight,
+    TopLeft,
+    TopCenter,
+    TopRight:
+    Custom Anchor::Custom(_) => Vec2::default()
 );
 
 impl_for_struct_delegate_fields!(bevy::sprite::Rect:

--- a/src/utils/macros.rs
+++ b/src/utils/macros.rs
@@ -18,6 +18,36 @@ macro_rules! impl_for_simple_enum {
                 changed
             }
         }
+    };
+    ($name:ty: $($variant:ident),* : $($variant1:ident $val:pat => $default:expr),*) => {
+        impl $crate::Inspectable for $name {
+            type Attributes = ();
+
+            fn ui(&mut self, ui: &mut $crate::egui::Ui, _: Self::Attributes, context: &mut $crate::Context) -> bool {
+                let mut changed = false;
+                crate::egui::ComboBox::from_id_source(context.id())
+                    .selected_text(format!("{:?}", self))
+                    .show_ui(ui, |ui| {
+                    $(
+                        if ui.selectable_label(matches!(self, <$name>::$variant), format!("{:?}", <$name>::$variant)).clicked() {
+                            *self = <$name>::$variant;
+                            changed = true;
+                        }
+                    )*
+                    $(
+                        if ui.selectable_label(matches!(self, $val), format!("{:?}", stringify!(&variant1))).clicked() {
+                            if let $val = self {
+                                
+                            } else {
+                                *self = <$name>::$variant1($default);
+                                changed = true;
+                            }
+                        }
+                    )*
+                });
+                changed
+            }
+        }
     }
 }
 

--- a/src/utils/macros.rs
+++ b/src/utils/macros.rs
@@ -35,7 +35,7 @@ macro_rules! impl_for_simple_enum {
                         }
                     )*
                     $(
-                        if ui.selectable_label(matches!(self, $val), format!("{:?}", stringify!(&variant1))).clicked() {
+                        if ui.selectable_label(matches!(self, $val), format!("{:?}", $default)).clicked() {
                             if let $val = self {
                                 
                             } else {

--- a/src/utils/macros.rs
+++ b/src/utils/macros.rs
@@ -35,15 +35,52 @@ macro_rules! impl_for_simple_enum {
                         }
                     )*
                     $(
-                        if ui.selectable_label(matches!(self, $val), format!("{:?}", $default)).clicked() {
+                        if ui.selectable_label(matches!(self, $val), stringify!($variant1)).clicked() {
                             if let $val = self {
-                                
+
                             } else {
                                 *self = <$name>::$variant1($default);
                                 changed = true;
                             }
                         }
                     )*
+                });
+                changed
+            }
+        }
+    };
+    ($name:ty: $($variant:ident),* : $($variant1:ident $val:pat => $default:expr),*; $(if let $pat1:pat => $ui:expr),*) => {
+        impl $crate::Inspectable for $name {
+            type Attributes = ();
+
+            fn ui(&mut self, ui: &mut $crate::egui::Ui, _: Self::Attributes, context: &mut $crate::Context) -> bool {
+                let mut changed = false;
+                ui.horizontal(|ui| {
+                crate::egui::ComboBox::from_id_source(context.id())
+                    .selected_text(format!("{:?}", self))
+                    .show_ui(ui, |ui| {
+                    $(
+                        if ui.selectable_label(matches!(self, <$name>::$variant), format!("{:?}", <$name>::$variant)).clicked() {
+                            *self = <$name>::$variant;
+                            changed = true;
+                        }
+                    )*
+                    $(
+                        if ui.selectable_label(matches!(self, $val), stringify!($variant1)).clicked() {
+                            if let $val = self {
+
+                            } else {
+                                *self = <$name>::$variant1($default);
+                                changed = true;
+                            }
+                        }
+                    )*
+                });
+                $(
+                    if let $pat1 = self {
+                        $ui(ui, context);
+                    }
+                )*
                 });
                 changed
             }


### PR DESCRIPTION
expanded the impl_for_simple_enum macro so it can take in tuple variants and added the sprite Anchor to the sprites inspector derive.
the macro needs some work since I don't have any experience with macros and the docs are confusing and missing lots of details. any links to good resources would be appreciated.