### PR TITLE
Update rapier inspector to bevy 0.9

### DIFF
--- a/integrations/bevy-inspector-egui-rapier/Cargo.toml
+++ b/integrations/bevy-inspector-egui-rapier/Cargo.toml
@@ -2,7 +2,7 @@
 edition = "2021"
 name = "bevy-inspector-egui-rapier"
 repository = "https://github.com/jakobhellermann/bevy-inspector-egui/"
-version = "0.7.0"
+version = "0.8.0"
 
 categories = ["game-development", "gui", "visualization"]
 description = "bevy-inspector-egui integration for rapier"
@@ -15,13 +15,13 @@ rapier2d = ["bevy_rapier2d"]
 rapier3d = ["bevy_rapier3d"]
 
 [dependencies]
-bevy = {version = "0.8", default-features = false}
-bevy-inspector-egui = {version = "0.13", path = "../..", features = ["nalgebra031"]}
-bevy_rapier2d = {version = "0.18", optional = true}
-bevy_rapier3d = {version = "0.18", optional = true}
+bevy = {version = "0.9", default-features = false}
+bevy-inspector-egui = {version = "0.14", path = "../..", features = ["nalgebra031"]}
+bevy_rapier2d = {version = "0.19", optional = true}
+bevy_rapier3d = {version = "0.19", optional = true}
 
 [dev-dependencies]
-bevy = {version = "0.8", default-features = false, features = ["x11", "bevy_winit"]}
+bevy = {version = "0.9", default-features = false, features = ["x11", "bevy_winit"]}
 
 [[example]]
 name = "rapier2d"


### PR DESCRIPTION
Since `bevy-rapier` [updated and released](https://github.com/dimforge/bevy_rapier/releases/tag/v0.19.0) support for 0.9, this can also be updated. It just required version bumps. I tried it in my project and it seems to be working as expected. You can close this if additional changes are needed