### PR TITLE
Fix font file path in demo example

### DIFF
--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -82,7 +82,7 @@ fn shape_update_system(data: Res<Data>, mut query: Query<(&mut Sprite, &mut Tran
 }
 
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
-    let font_handle = asset_server.load("/usr/share/fonts/truetype/noto/NotoMono-Regular.ttf");
+    let font_handle = asset_server.load("fonts/FiraSans-Bold.ttf");
 
     commands.spawn(Camera2dBundle::default());
     commands.spawn(TextBundle {


### PR DESCRIPTION
On Windows, no text appears in the demo example.

This PR changes the font path to the one included in the repo, so that the text appears on other systems (Windows).