### PR TITLE
Upgrade rework branch dependencies

### DIFF
--- a/crates/bevy-inspector-egui/Cargo.toml
+++ b/crates/bevy-inspector-egui/Cargo.toml
@@ -23,13 +23,13 @@ bevy_math = { version = "0.9" }
 bevy_core_pipeline = { version = "0.9" }
 bevy_utils = { version = "0.9" }
 
-egui = "0.19.0"
+egui = "0.20.0"
 bevy_egui = "0.17"
 
-image = { version = "0.24.3", default-features = false }
-once_cell = "1.14.0"
+image = { version = "0.24.5", default-features = false }
+once_cell = "1.16.0"
 pretty-type-name = "1.0.0"
-smallvec = "1.9.0"
+smallvec = "1.10.0"
 
 [dev-dependencies]
 bevy = { version = "0.9", default-features = false, features = ["render", "x11", "bevy_winit", "animation", "png"] }


### PR DESCRIPTION
`bevy_dock` just released a new version with `egui = "0.20.0"` and inspector became incompatible with it :disappointed:. This PR is simple `cargo upgrade` on the rework branch.