### PR TITLE
Feat: egui mouse check

### DIFF
--- a/crates/bevy-inspector-egui/Cargo.toml
+++ b/crates/bevy-inspector-egui/Cargo.toml
@@ -88,6 +88,10 @@ name = "world_inspector"
 path = "examples/quick/world_inspector.rs"
 
 [[example]]
+name = "world_inspector_mouse_check"
+path = "examples/quick/world_inspector_mouse_check.rs"
+
+[[example]]
 name = "world_inspector_assets"
 path = "examples/quick/world_inspector_assets.rs"
 

--- a/crates/bevy-inspector-egui/examples/README.md
+++ b/crates/bevy-inspector-egui/examples/README.md
@@ -5,6 +5,7 @@
   - [`resource_inspector_manual.rs`](./basic/resource_inspector_manual.rs) Shows how to customize and build your own inspector windows
 - `quick` - Demonstrations of the quick plugins
   - [`world_inspector.rs`](./quick/world_inspector.rs) Example of the `WorldInspectorPlugin`
+  - [`world_inspector_mouse_check.rs`](./quick/world_inspector_mouse_check.rs) Example of the `WorldInspectorPlugin` with camera and checking for egui components
   - [`resource_inspector.rs`](./quick/resource_inspector.rs) Example of the `ResourceInspectorPlugin`
   - [`filter_query_inspector.rs`](./quick/filter_query_inspector.rs) Example of the `FilterQueryInspectorPlugin`
   - [`asset_inspector.rs`](./quick/asset_inspector.rs) Example of the `AssetInspectorPlugin`

--- a/crates/bevy-inspector-egui/examples/quick/world_inspector_mouse_check.rs
+++ b/crates/bevy-inspector-egui/examples/quick/world_inspector_mouse_check.rs
@@ -7,15 +7,11 @@ use bevy_inspector_egui::quick::WorldInspectorPlugin;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugins(
+        .add_plugins((
             WorldInspectorPlugin::default().run_if(input_toggle_active(true, KeyCode::Escape)),
-        )
-        .init_resource::<egui_mouse_check::EguiMousePointerCheck>()
-        .add_systems(
-            Startup,
-            (setup, egui_mouse_check::initialize_egui_mouse_check),
-        )
-        .add_systems(PreUpdate, egui_mouse_check::update_egui_mouse_check)
+            egui_mouse_check::EguiMouseCheck::default(),
+        ))
+        .add_systems(Startup, setup)
         .add_systems(
             Update,
             (camera_pan, camera_zoom).run_if(egui_mouse_check::mouse_pointer_valid()),

--- a/crates/bevy-inspector-egui/examples/quick/world_inspector_mouse_check.rs
+++ b/crates/bevy-inspector-egui/examples/quick/world_inspector_mouse_check.rs
@@ -1,0 +1,99 @@
+use bevy::input::common_conditions::input_toggle_active;
+use bevy::input::mouse;
+use bevy::prelude::*;
+use bevy_inspector_egui::egui_mouse_check;
+use bevy_inspector_egui::quick::WorldInspectorPlugin;
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_plugins(
+            WorldInspectorPlugin::default().run_if(input_toggle_active(true, KeyCode::Escape)),
+        )
+        .init_resource::<egui_mouse_check::EguiMousePointerCheck>()
+        .add_systems(
+            Startup,
+            (setup, egui_mouse_check::initialize_egui_mouse_check),
+        )
+        .add_systems(PreUpdate, egui_mouse_check::update_egui_mouse_check)
+        .add_systems(
+            Update,
+            (camera_pan, camera_zoom).run_if(egui_mouse_check::mouse_pointer_valid()),
+        )
+        .run();
+}
+
+#[derive(Component)]
+struct MainCamera;
+
+/// set up a simple 3D scene
+fn setup(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+) {
+    // plane
+    commands.spawn(PbrBundle {
+        mesh: meshes.add(Mesh::from(shape::Plane::from_size(5.0))),
+        material: materials.add(Color::rgb(0.3, 0.5, 0.3).into()),
+        ..default()
+    });
+    // cube
+    commands.spawn(PbrBundle {
+        mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
+        material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
+        transform: Transform::from_xyz(0.0, 0.5, 0.0),
+        ..default()
+    });
+    // light
+    commands.spawn(PointLightBundle {
+        point_light: PointLight {
+            intensity: 1500.0,
+            shadows_enabled: true,
+            ..default()
+        },
+        transform: Transform::from_xyz(4.0, 8.0, 4.0),
+        ..default()
+    });
+    // camera
+    commands.spawn((
+        MainCamera,
+        Camera3dBundle {
+            transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
+            ..default()
+        },
+    ));
+}
+
+fn camera_pan(
+    mouse: Res<Input<MouseButton>>,
+    mut motion_evr: EventReader<mouse::MouseMotion>,
+    mut camera_q: Query<&mut Transform, With<MainCamera>>,
+) {
+    const SENSITIVITY: f32 = 0.005;
+    let mut camera_transform = camera_q.single_mut();
+
+    if mouse.any_pressed([MouseButton::Left, MouseButton::Right]) {
+        for e in motion_evr.iter() {
+            let y_rotation = Quat::from_rotation_y(e.delta.x * SENSITIVITY);
+            camera_transform.rotate_around(Vec3::ZERO, y_rotation);
+        }
+    }
+}
+
+fn camera_zoom(
+    mut scroll_evr: EventReader<mouse::MouseWheel>,
+    mut camera_q: Query<&mut Transform, With<MainCamera>>,
+) {
+    let mut camera_transform = camera_q.single_mut();
+
+    for e in scroll_evr.iter() {
+        let dir = -e.y.signum();
+        let n = camera_transform.translation.normalize() * dir * 2.;
+
+        camera_transform.translation += n;
+        camera_transform
+            .translation
+            .clamp(Vec3::splat(10.0), Vec3::splat(25.0));
+    }
+}

--- a/crates/bevy-inspector-egui/src/egui_mouse_check.rs
+++ b/crates/bevy-inspector-egui/src/egui_mouse_check.rs
@@ -1,0 +1,45 @@
+use bevy_ecs::prelude::*;
+use bevy_egui::EguiContexts;
+use bevy_log::error;
+use bevy_window::PrimaryWindow;
+
+#[derive(Resource)]
+pub struct EguiMousePointerCheck {
+    pointer_is_valid: bool,
+    primary_window: Option<Entity>,
+}
+
+impl Default for EguiMousePointerCheck {
+    fn default() -> EguiMousePointerCheck {
+        EguiMousePointerCheck {
+            pointer_is_valid: true,
+            primary_window: None,
+        }
+    }
+}
+
+pub fn initialize_egui_mouse_check(
+    mut egui_check: ResMut<EguiMousePointerCheck>,
+    window_q: Query<Entity, With<PrimaryWindow>>,
+) {
+    if let Ok(window_id) = window_q.get_single() {
+        egui_check.primary_window = Some(window_id);
+    } else {
+        error!("could not get Primary Window");
+    }
+}
+
+pub fn update_egui_mouse_check(
+    mut egui_checker: ResMut<EguiMousePointerCheck>,
+    mut egui_ctxs: EguiContexts,
+) {
+    if let Some(window_id) = egui_checker.primary_window {
+        egui_checker.pointer_is_valid = !egui_ctxs
+            .ctx_for_window_mut(window_id)
+            .wants_pointer_input();
+    }
+}
+
+pub fn mouse_pointer_valid() -> impl FnMut(Res<EguiMousePointerCheck>) -> bool + Clone {
+    move |egui_mouse_check: Res<EguiMousePointerCheck>| egui_mouse_check.pointer_is_valid
+}

--- a/crates/bevy-inspector-egui/src/egui_mouse_check.rs
+++ b/crates/bevy-inspector-egui/src/egui_mouse_check.rs
@@ -1,7 +1,19 @@
+use bevy_app::{App, Plugin, PreUpdate, Startup};
 use bevy_ecs::prelude::*;
 use bevy_egui::EguiContexts;
 use bevy_log::error;
 use bevy_window::PrimaryWindow;
+
+#[derive(Default)]
+pub struct EguiMouseCheck;
+
+impl Plugin for EguiMouseCheck {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<EguiMousePointerCheck>()
+            .add_systems(Startup, initialize_egui_mouse_check)
+            .add_systems(PreUpdate, update_egui_mouse_check);
+    }
+}
 
 #[derive(Resource)]
 pub struct EguiMousePointerCheck {
@@ -40,6 +52,6 @@ pub fn update_egui_mouse_check(
     }
 }
 
-pub fn mouse_pointer_valid() -> impl FnMut(Res<EguiMousePointerCheck>) -> bool + Clone {
+pub fn mouse_pointer_valid() -> impl Fn(Res<EguiMousePointerCheck>) -> bool + Clone {
     move |egui_mouse_check: Res<EguiMousePointerCheck>| egui_mouse_check.pointer_is_valid
 }

--- a/crates/bevy-inspector-egui/src/lib.rs
+++ b/crates/bevy-inspector-egui/src/lib.rs
@@ -137,6 +137,8 @@ pub mod quick;
 pub mod reflect_inspector;
 pub mod restricted_world_view;
 
+pub mod egui_mouse_check;
+
 mod egui_utils;
 mod utils;
 


### PR DESCRIPTION
Added a resource which tracks wether mouse pointer should be handled the egui or Bevy's running systems. This gets rid of annoyance where one drags the egui window around (or scrolls through it) and that input is picked up by the Bevy's systems as a normal user input.

This could potentially be in [Bevy's common input conditions](https://github.com/bevyengine/bevy/blob/main/crates/bevy_input/src/common_conditions.rs), however it is not really *common* since it only occurrs when integrating with other Plugins.

Although this is simply a difference of how the inspector is integrated, I still put it under the `quick` examples, since it is strictly an upgrade from [World Inspector example](https://github.com/jakobhellermann/bevy-inspector-egui/blob/main/crates/bevy-inspector-egui/examples/quick/world_inspector.rs) and is not really on the level of other `integrations` examples.

Only works for primary window.