### PR TITLE
update add_plugin to add_plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ use bevy_inspector_egui::quick::WorldInspectorPlugin;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugin(WorldInspectorPlugin::new())
+        .add_plugins(WorldInspectorPlugin::new())
         .run();
 }
 ```
@@ -53,9 +53,9 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .init_resource::<Configuration>() // `ResourceInspectorPlugin` won't initialize the resource
         .register_type::<Configuration>() // you need to register your type to display it
-        .add_plugin(ResourceInspectorPlugin::<Configuration>::default())
+        .add_plugins(ResourceInspectorPlugin::<Configuration>::default())
         // also works with built-in resources, as long as they are `Reflect`
-        .add_plugin(ResourceInspectorPlugin::<Time>::default())
+        .add_plugins(ResourceInspectorPlugin::<Time>::default())
         .run();
 }
 ```
@@ -76,8 +76,8 @@ use std::any::TypeId;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugin(EguiPlugin)
-        .add_plugin(bevy_inspector_egui::DefaultInspectorConfigPlugin) // adds default options and `InspectorEguiImpl`s
+        .add_plugins(EguiPlugin)
+        .add_plugins(bevy_inspector_egui::DefaultInspectorConfigPlugin) // adds default options and `InspectorEguiImpl`s
         .add_systems(Update, inspector_ui)
         .run();
 }

--- a/crates/bevy-inspector-egui/examples/integrations/egui_dock.rs
+++ b/crates/bevy-inspector-egui/examples/integrations/egui_dock.rs
@@ -20,7 +20,7 @@ use egui_gizmo::{Gizmo, GizmoMode, GizmoOrientation};
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        // .add_plugin(bevy_framepace::FramepacePlugin) // reduces input lag
+        // .add_plugins(bevy_framepace::FramepacePlugin) // reduces input lag
         .add_plugins(DefaultInspectorConfigPlugin)
         .add_plugins(bevy_egui::EguiPlugin)
         // .add_plugins(bevy_mod_picking::plugins::DefaultPickingPlugins)

--- a/crates/bevy-inspector-egui/src/lib.rs
+++ b/crates/bevy-inspector-egui/src/lib.rs
@@ -31,7 +31,7 @@
 //! fn main() {
 //!     App::new()
 //!         .add_plugins(DefaultPlugins)
-//!         .add_plugin(WorldInspectorPlugin::new())
+//!         .add_plugins(WorldInspectorPlugin::new())
 //!         .run();
 //! }
 //!
@@ -60,9 +60,9 @@
 //!         .add_plugins(DefaultPlugins)
 //!         .init_resource::<Configuration>() // `ResourceInspectorPlugin` won't initialize the resource
 //!         .register_type::<Configuration>() // you need to register your type to display it
-//!         .add_plugin(ResourceInspectorPlugin::<Configuration>::default())
+//!         .add_plugins(ResourceInspectorPlugin::<Configuration>::default())
 //!         // also works with built-in resources, as long as they implement `Reflect`
-//!         .add_plugin(ResourceInspectorPlugin::<Time>::default())
+//!         .add_plugins(ResourceInspectorPlugin::<Time>::default())
 //!         .run();
 //! }
 //! ```
@@ -85,8 +85,8 @@
 //! fn main() {
 //!     App::new()
 //!         .add_plugins(DefaultPlugins)
-//!         .add_plugin(EguiPlugin)
-//!         .add_plugin(bevy_inspector_egui::DefaultInspectorConfigPlugin) // adds default options and `InspectorEguiImpl`s
+//!         .add_plugins(EguiPlugin)
+//!         .add_plugins(bevy_inspector_egui::DefaultInspectorConfigPlugin) // adds default options and `InspectorEguiImpl`s
 //!         .add_systems(Update, inspector_ui)
 //!         .run();
 //! }

--- a/crates/bevy-inspector-egui/src/quick.rs
+++ b/crates/bevy-inspector-egui/src/quick.rs
@@ -36,7 +36,7 @@ const DEFAULT_SIZE: (f32, f32) = (320., 160.);
 /// fn main() {
 ///     App::new()
 ///         .add_plugins(DefaultPlugins)
-///         .add_plugin(WorldInspectorPlugin::new())
+///         .add_plugins(WorldInspectorPlugin::new())
 ///         .run();
 /// }
 /// ```
@@ -121,9 +121,9 @@ fn world_inspector_ui(world: &mut World) {
 ///         .add_plugins(DefaultPlugins)
 ///         .init_resource::<Configuration>() // `ResourceInspectorPlugin` won't initialize the resource
 ///         .register_type::<Configuration>() // you need to register your type to display it
-///         .add_plugin(ResourceInspectorPlugin::<Configuration>::default())
+///         .add_plugins(ResourceInspectorPlugin::<Configuration>::default())
 ///         // also works with built-in resources, as long as they implement `Reflect`
-///         .add_plugin(ResourceInspectorPlugin::<Time>::default())
+///         .add_plugins(ResourceInspectorPlugin::<Time>::default())
 ///         .run();
 /// }
 /// ```
@@ -209,7 +209,7 @@ fn inspector_ui<T: Resource + Reflect>(world: &mut World) {
 ///         .insert_resource(ClearColor(Color::BLACK))
 ///         .add_state::<AppState>()
 ///         .register_type::<AppState>()
-///         .add_plugin(StateInspectorPlugin::<AppState>::default())
+///         .add_plugins(StateInspectorPlugin::<AppState>::default())
 ///         .run();
 /// }
 ///
@@ -299,7 +299,7 @@ fn state_ui<T: States + Reflect>(world: &mut World) {
 /// fn main() {
 ///     App::new()
 ///         .add_plugins(DefaultPlugins)
-///         .add_plugin(AssetInspectorPlugin::<StandardMaterial>::default())
+///         .add_plugins(AssetInspectorPlugin::<StandardMaterial>::default())
 ///         .run();
 /// }
 /// ```
@@ -376,7 +376,7 @@ fn asset_inspector_ui<A: Asset + Reflect>(world: &mut World) {
 /// fn main() {
 ///     App::new()
 ///         .add_plugins(DefaultPlugins)
-///         .add_plugin(FilterQueryInspectorPlugin::<With<Transform>>::default())
+///         .add_plugins(FilterQueryInspectorPlugin::<With<Transform>>::default())
 ///         .run();
 /// }
 /// ```

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -187,7 +187,7 @@
   When access to the resources is needed, add the plugin like
 
   ```rust
-  add.add_plugin(InspectorPlugin::<T>::thread_local())
+  add.add_plugins(InspectorPlugin::<T>::thread_local())
   ```
 
 - implementations of `Inspectable` for `StandardMaterial` and `Range{,Inclusive}<T>`

--- a/docs/MIGRATION_GUIDE_0.15_0.16.md
+++ b/docs/MIGRATION_GUIDE_0.15_0.16.md
@@ -5,7 +5,7 @@
 - `InspectorPlugin` got moved to `quick::ResourceInspectorPlugin`
     - it doesn't automatically insert the resource anymore
     - you need to derive `Reflect` instead of `Inspectable` and call `.register_type`
-- `InspectorQuery` doesn't exist anymore. To show all entities matching a query, use `.add_plugin(FilterQueryInspectorPlugin::<With<Transform>>::default())`,
+- `InspectorQuery` doesn't exist anymore. To show all entities matching a query, use `.add_plugins(FilterQueryInspectorPlugin::<With<Transform>>::default())`,
 for anything else you have to write your own UI logic:
 ```rust
 let mut query = world.query::<&Handle<StandardMaterial>>();


### PR DESCRIPTION
Hi, guys!

Since `bevy-inspector-egui` updated and released support for 0.11.0, this can also be updated. It just required version bumps. I tried it in my project and it seems to be working as expected. You can close this if additional changes are needed.

[Deprecated since 0.11.0: Please use add_plugins instead.](https://docs.rs/bevy/0.11.0/bevy/app/struct.App.html#method.add_plugin)
