### PR TITLE
Add reflected Map controls

### DIFF
--- a/crates/bevy-inspector-egui/examples/basic/inspector_options.rs
+++ b/crates/bevy-inspector-egui/examples/basic/inspector_options.rs
@@ -6,7 +6,7 @@ use bevy_pbr::PbrBundle;
 use bevy_utils::HashMap;
 use bevy_window::PrimaryWindow;
 
-#[derive(Reflect, Default, InspectorOptions)]
+#[derive(Reflect, InspectorOptions)]
 #[reflect(InspectorOptions)]
 struct Config {
     // `f32` uses `NumberOptions<f32>`
@@ -17,6 +17,17 @@ struct Config {
     #[inspector(min = 10, max = 20)] // same for Vec<T>
     vec: Vec<u32>,
     hash_map: HashMap<u32, String>,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            font_size: 0.,
+            option: None,
+            vec: Vec::default(),
+            hash_map: HashMap::from([(0, "foo".to_owned()), (1, "bar".to_owned())]),
+        }
+    }
 }
 
 // Enums can be have `InspectorOptions` as well.

--- a/crates/bevy-inspector-egui/examples/basic/inspector_options.rs
+++ b/crates/bevy-inspector-egui/examples/basic/inspector_options.rs
@@ -3,6 +3,7 @@ use bevy_egui::EguiContext;
 use bevy_inspector_egui::inspector_options::std_options::NumberDisplay;
 use bevy_inspector_egui::{prelude::*, DefaultInspectorConfigPlugin};
 use bevy_pbr::PbrBundle;
+use bevy_utils::HashMap;
 use bevy_window::PrimaryWindow;
 
 #[derive(Reflect, Default, InspectorOptions)]
@@ -15,6 +16,7 @@ struct Config {
     option: Option<f32>,
     #[inspector(min = 10, max = 20)] // same for Vec<T>
     vec: Vec<u32>,
+    hash_map: HashMap<u32, String>,
 }
 
 // Enums can be have `InspectorOptions` as well.

--- a/crates/bevy-inspector-egui/src/reflect_inspector/mod.rs
+++ b/crates/bevy-inspector-egui/src/reflect_inspector/mod.rs
@@ -925,6 +925,7 @@ impl InspectorUi<'_, '_> {
         let map_draft_id = id.with("map_draft");
         if map.len() == 0 {
             ui.label("(Empty Map)");
+            ui.end_row();
         }
         let draft_clone = ui.data_mut(|data| {
             data.get_temp_mut_or_default::<Option<MapDraftElement>>(map_draft_id)


### PR DESCRIPTION
This PR adds support for editing reflected `Map` values. Specifically:

- mutable fields support for editing `Map` values in-place
- adds 'remove element' buttons for each key-value pair
- adds a 'draft element' field to edit and add new key-value pairs

<img width="225" alt="image" src="https://github.com/jakobhellermann/bevy-inspector-egui/assets/12357846/f465a259-6176-47ed-8496-2d56939e761a">
<img width="299" alt="image" src="https://github.com/jakobhellermann/bevy-inspector-egui/assets/12357846/54fb3d58-6725-407f-9a26-90587286b337">

It should be noted the 'add element' draft implementation is pretty inefficient. It uses egui's `IdTypeMap` which internally clones the element, and also clones the element itself to move the value out of state for use. If we have a better way to store this (on the `InspectorUi` struct? in the Bevy world?) that would be an improvement.