### PR TITLE
Two points of UI optimization.

### DIFF
--- a/crates/bevy-inspector-egui/examples/basic/inspector_options.rs
+++ b/crates/bevy-inspector-egui/examples/basic/inspector_options.rs
@@ -91,7 +91,7 @@ fn ui_example(world: &mut World) {
         .clone();
 
     egui::Window::new("UI").show(egui_context.get_mut(), |ui| {
-        egui::ScrollArea::vertical().show(ui, |ui| {
+        egui::ScrollArea::both().show(ui, |ui| {
             bevy_inspector_egui::bevy_inspector::ui_for_resource::<UiData>(world, ui);
         });
     });

--- a/crates/bevy-inspector-egui/examples/basic/resource_inspector_manual.rs
+++ b/crates/bevy-inspector-egui/examples/basic/resource_inspector_manual.rs
@@ -46,7 +46,7 @@ fn inspector_ui(world: &mut World, mut disabled: Local<bool>) {
 
     // the usual `ResourceInspector` code
     egui::Window::new("Resource Inspector").show(egui_context.get_mut(), |ui| {
-        egui::ScrollArea::vertical().show(ui, |ui| {
+        egui::ScrollArea::both().show(ui, |ui| {
             bevy_inspector_egui::bevy_inspector::ui_for_resource::<Configuration>(world, ui);
 
             ui.separator();

--- a/crates/bevy-inspector-egui/examples/integrations/side_panel.rs
+++ b/crates/bevy-inspector-egui/examples/integrations/side_panel.rs
@@ -27,7 +27,7 @@ fn inspector_ui(world: &mut World, mut selected_entities: Local<SelectedEntities
     egui::SidePanel::left("hierarchy")
         .default_width(200.0)
         .show(egui_context.get_mut(), |ui| {
-            egui::ScrollArea::vertical().show(ui, |ui| {
+            egui::ScrollArea::both().show(ui, |ui| {
                 ui.heading("Hierarchy");
 
                 bevy_inspector_egui::bevy_inspector::hierarchy::hierarchy_ui(
@@ -44,7 +44,7 @@ fn inspector_ui(world: &mut World, mut selected_entities: Local<SelectedEntities
     egui::SidePanel::right("inspector")
         .default_width(250.0)
         .show(egui_context.get_mut(), |ui| {
-            egui::ScrollArea::vertical().show(ui, |ui| {
+            egui::ScrollArea::both().show(ui, |ui| {
                 ui.heading("Inspector");
 
                 match selected_entities.as_slice() {

--- a/crates/bevy-inspector-egui/src/lib.rs
+++ b/crates/bevy-inspector-egui/src/lib.rs
@@ -98,7 +98,7 @@
 //!         .clone();
 //!
 //!     egui::Window::new("UI").show(egui_context.get_mut(), |ui| {
-//!         egui::ScrollArea::vertical().show(ui, |ui| {
+//!         egui::ScrollArea::both().show(ui, |ui| {
 //!             // equivalent to `WorldInspectorPlugin`
 //!             bevy_inspector::ui_for_world(world, ui);
 //!             

--- a/crates/bevy-inspector-egui/src/quick.rs
+++ b/crates/bevy-inspector-egui/src/quick.rs
@@ -91,7 +91,7 @@ fn world_inspector_ui(world: &mut World) {
     egui::Window::new("World Inspector")
         .default_size(DEFAULT_SIZE)
         .show(egui_context.get_mut(), |ui| {
-            egui::ScrollArea::vertical().show(ui, |ui| {
+            egui::ScrollArea::both().show(ui, |ui| {
                 bevy_inspector::ui_for_world(world, ui);
                 ui.allocate_space(ui.available_size());
             });
@@ -189,7 +189,7 @@ fn inspector_ui<T: Resource + Reflect>(world: &mut World) {
     egui::Window::new(pretty_type_name::<T>())
         .default_size((0., 0.))
         .show(egui_context.get_mut(), |ui| {
-            egui::ScrollArea::vertical().show(ui, |ui| {
+            egui::ScrollArea::both().show(ui, |ui| {
                 bevy_inspector::ui_for_resource::<T>(world, ui);
 
                 ui.allocate_space(ui.available_size());
@@ -285,7 +285,7 @@ fn state_ui<T: States + Reflect>(world: &mut World) {
         .resizable(false)
         .title_bar(false)
         .show(egui_context.get_mut(), |ui| {
-            egui::ScrollArea::vertical().show(ui, |ui| {
+            egui::ScrollArea::both().show(ui, |ui| {
                 ui.heading(pretty_type_name::<T>());
                 bevy_inspector::ui_for_state::<T>(world, ui);
             });
@@ -368,7 +368,7 @@ fn asset_inspector_ui<A: Asset + Reflect>(world: &mut World) {
     egui::Window::new(pretty_type_name::<A>())
         .default_size(DEFAULT_SIZE)
         .show(egui_context.get_mut(), |ui| {
-            egui::ScrollArea::vertical().show(ui, |ui| {
+            egui::ScrollArea::both().show(ui, |ui| {
                 bevy_inspector::ui_for_assets::<A>(world, ui);
 
                 ui.allocate_space(ui.available_size());
@@ -451,7 +451,7 @@ fn entity_query_ui<F: ReadOnlyWorldQuery>(world: &mut World) {
     egui::Window::new(pretty_type_name::<F>())
         .default_size(DEFAULT_SIZE)
         .show(egui_context.get_mut(), |ui| {
-            egui::ScrollArea::vertical().show(ui, |ui| {
+            egui::ScrollArea::both().show(ui, |ui| {
                 bevy_inspector::ui_for_world_entities_filtered::<F>(world, ui, false);
                 ui.allocate_space(ui.available_size());
             });

--- a/crates/bevy-inspector-egui/src/reflect_inspector/mod.rs
+++ b/crates/bevy-inspector-egui/src/reflect_inspector/mod.rs
@@ -398,7 +398,7 @@ fn ui_for_empty_list(ui: &mut egui::Ui) -> bool {
 fn ui_for_list_controls(ui: &mut egui::Ui, index: usize, len: usize) -> Option<ListOp> {
     use ListOp::*;
     let mut op = None;
-    ui.horizontal(|ui| {
+    ui.horizontal_top(|ui| {
         if add_button(ui).on_hover_text("Add element").clicked() {
             op = Some(AddElement(index));
         }
@@ -763,7 +763,7 @@ impl InspectorUi<'_, '_> {
                 egui::Grid::new((id, i)).show(ui, |ui| {
                     ui.label(i.to_string());
                     let val = list.get_mut(i).unwrap();
-                    ui.horizontal(|ui| {
+                    ui.horizontal_top(|ui| {
                         changed |= self.ui_for_reflect_with_options(val, ui, id.with(i), options);
                     });
                     ui.end_row();
@@ -813,7 +813,7 @@ impl InspectorUi<'_, '_> {
             let len = list.len();
             for i in 0..len {
                 let val = list.get(i).unwrap();
-                ui.horizontal(|ui| {
+                ui.horizontal_top(|ui| {
                     self.ui_for_reflect_readonly_with_options(val, ui, id.with(i), options)
                 });
 
@@ -869,7 +869,7 @@ impl InspectorUi<'_, '_> {
 
                 egui::Grid::new((id, i)).show(ui, |ui| {
                     ui.label(i.to_string());
-                    ui.horizontal(|ui| {
+                    ui.horizontal_top(|ui| {
                         changed |= self.ui_for_reflect_many_with_options(
                             info.item_type_id(),
                             info.type_path(),
@@ -1039,7 +1039,7 @@ impl InspectorUi<'_, '_> {
             let len = array.len();
             for i in 0..len {
                 let val = array.get_mut(i).unwrap();
-                ui.horizontal(|ui| {
+                ui.horizontal_top(|ui| {
                     changed |= self.ui_for_reflect_with_options(val, ui, id.with(i), options);
                 });
 
@@ -1063,7 +1063,7 @@ impl InspectorUi<'_, '_> {
             let len = array.len();
             for i in 0..len {
                 let val = array.get(i).unwrap();
-                ui.horizontal(|ui| {
+                ui.horizontal_top(|ui| {
                     self.ui_for_reflect_readonly_with_options(val, ui, id.with(i), options);
                 });
 
@@ -1258,7 +1258,7 @@ impl InspectorUi<'_, '_> {
     ) -> Option<(usize, DynamicEnum)> {
         let mut changed_variant = None;
 
-        ui.horizontal(|ui| {
+        ui.horizontal_top(|ui| {
             egui::ComboBox::new(id.with("select"), "")
                 .selected_text(info.variant_names()[active_variant_idx])
                 .show_ui(ui, |ui| {


### PR DESCRIPTION
As mentioned in the commits, there are mainly two points:

1. Change `egui::ScrollArea::vertical` to `both`
This allows a very deep node expansion relationship not to be too wide for display.
![image](https://github.com/jakobhellermann/bevy-inspector-egui/assets/25105117/4ae65d7b-54e1-4584-815f-c79d0ba05327)

3. Change `ui.horizontal` to `horizontal_top`
This fixes the incorrect blank space above the expanded node.
![image](https://github.com/jakobhellermann/bevy-inspector-egui/assets/25105117/863e6137-26d6-44cc-b335-890cd18b51fb)

