### PR TITLE
Update egui to 0.24

### DIFF
--- a/crates/bevy-inspector-egui/Cargo.toml
+++ b/crates/bevy-inspector-egui/Cargo.toml
@@ -37,8 +37,8 @@ bevy_core_pipeline = { version = "0.12" }
 bevy_pbr = { version = "0.12", optional = true }
 bevy_render = { version = "0.12" }
 
-egui = "0.23"
-bevy_egui = "0.23"
+egui = "0.24"
+bevy_egui = "0.24"
 
 image = { version = "0.24", default-features = false }
 once_cell = "1.16"
@@ -58,8 +58,8 @@ bevy = { version = "0.12", default-features = false, features = [
     "tonemapping_luts",
     "ktx2",
 ] }
-egui_dock = "0.8"
-egui-gizmo = "0.12"
+egui_dock = "0.9"
+egui-gizmo = "0.13"
 # bevy_mod_picking = { git = "https://github.com/aevyrie/bevy_mod_picking", rev = "554649a951689dce66d0d759839b326874e8826f", default-features = false, features = ["backend_raycast", "backend_egui", "backend_sprite"] }
 # bevy_framepace = "0.11"
 

--- a/crates/bevy-inspector-egui/src/bevy_inspector/mod.rs
+++ b/crates/bevy-inspector-egui/src/bevy_inspector/mod.rs
@@ -496,7 +496,7 @@ pub fn ui_for_entities_shared_components(
     };
     let mut env = InspectorUi::for_bevy(&type_registry, &mut cx);
 
-    let id = egui::Id::null();
+    let id = egui::Id::NULL;
     for (name, component_id, component_type_id, size) in components {
         let id = id.with(component_id);
         egui::CollapsingHeader::new(&name)

--- a/crates/bevy-inspector-egui/src/reflect_inspector/mod.rs
+++ b/crates/bevy-inspector-egui/src/reflect_inspector/mod.rs
@@ -190,12 +190,12 @@ impl<'a, 'c> InspectorUi<'a, 'c> {
 impl InspectorUi<'_, '_> {
     /// Draws the inspector UI for the given value.
     pub fn ui_for_reflect(&mut self, value: &mut dyn Reflect, ui: &mut egui::Ui) -> bool {
-        self.ui_for_reflect_with_options(value, ui, egui::Id::null(), &())
+        self.ui_for_reflect_with_options(value, ui, egui::Id::NULL, &())
     }
 
     /// Draws the inspector UI for the given value in a read-only way.
     pub fn ui_for_reflect_readonly(&mut self, value: &dyn Reflect, ui: &mut egui::Ui) {
-        self.ui_for_reflect_readonly_with_options(value, ui, egui::Id::null(), &());
+        self.ui_for_reflect_readonly_with_options(value, ui, egui::Id::NULL, &());
     }
 
     /// Draws the inspector UI for the given value with some options.


### PR DESCRIPTION
Just a version bump. `egui::Id::null()` got deprecated, otherwise nothing much.