### PR TITLE
Also show entity ID besides name in restricted world view

### DIFF
--- a/crates/bevy-inspector-egui/src/utils.rs
+++ b/crates/bevy-inspector-egui/src/utils.rs
@@ -44,7 +44,7 @@ pub mod guess_entity_name {
                 if world.allows_access_to_component((entity, std::any::TypeId::of::<Name>())) {
                     // SAFETY: we have access and don't keep reference
                     if let Some(name) = unsafe { cell.get::<Name>() } {
-                        return name.as_str().to_string();
+                        return format!("{} ({:?})", name.as_str(), entity);
                     }
                 }
                 guess_entity_name_inner(world.world(), entity, cell.archetype())


### PR DESCRIPTION
I missed this in my other PR: https://github.com/jakobhellermann/bevy-inspector-egui/pull/172

I came across it in custom relations where the entity ID is still missing.