### PR TITLE
fix change detection in hierarchy ui

### DIFF
--- a/crates/bevy-inspector-egui/src/bevy_inspector/hierarchy.rs
+++ b/crates/bevy-inspector-egui/src/bevy_inspector/hierarchy.rs
@@ -112,7 +112,7 @@ impl<T> Hierarchy<'_, T> {
                 if let Some(children) = children {
                     let children = children.to_vec();
                     for &child in children.iter() {
-                        self.entity_ui(ui, child, always_open, &children);
+                        new_selection |= self.entity_ui(ui, child, always_open, &children);
                     }
                 } else {
                     ui.label("No children");


### PR DESCRIPTION
Fixes a bug where `hierarchy_ui` doesn't return `true` when the selection is modified by clicking on a nested entity.
This problem can be reproduced by running the `egui_dock` exmaple:
```sh
cargo run --example egui_dock
```
1. Expand the `Pbr Mesh (6v0)` entity on the left
2. Select any resource in `Resources`
3. Click on the nested `PointLight (7v0)` on the left

Doing so should update the inspector to display information about the point light but it doesn't because `hierarchy_ui` doesn't return `true` in this case:
https://github.com/aarthificial/bevy-inspector-egui/blob/1b916a05df5c04f342de53880130dcfcc345db24/crates/bevy-inspector-egui/examples/integrations/egui_dock.rs#L213-L216