### PR TITLE
replace `std::time::Instant` with `bevy_utils::Instant`

### DIFF
--- a/crates/bevy-inspector-egui/src/inspector_egui_impls/std_impls.rs
+++ b/crates/bevy-inspector-egui/src/inspector_egui_impls/std_impls.rs
@@ -1,6 +1,7 @@
-use std::{borrow::Cow, ops::AddAssign, path::PathBuf, time::Instant};
+use std::{borrow::Cow, ops::AddAssign, path::PathBuf};
 
 use bevy_reflect::{Reflect, TypePath};
+use bevy_utils::Instant;
 use egui::{DragValue, RichText, TextBuffer};
 
 use super::{change_slider, iter_all_eq, InspectorPrimitive, InspectorUi};


### PR DESCRIPTION
Building for WASM fails because `std::time::Instant` doesn't implement `Reflect` and `TypePath`. Replacing it with `bevy_utils::Instant` fixes this.