### PR TITLE
Added a dropdown to select loaded images in the inspector for Handle<Image>.

### DIFF
--- a/crates/bevy-inspector-egui/Cargo.toml
+++ b/crates/bevy-inspector-egui/Cargo.toml
@@ -45,6 +45,8 @@ once_cell = "1.16"
 pretty-type-name = "1.0"
 smallvec = "1.10"
 
+egui-dropdown = "0.7.0"
+
 [dev-dependencies]
 bevy = { version = "0.13", default-features = false, features = [
     "x11",


### PR DESCRIPTION
Hiya! Took a crack at this as discussed in Discord.

Looks like a big change, but a large part of the diff is just moving some of the functionality from `ui_readonly` to a `update_and_show_image` function to make passing the world a little easier between it and the mutable `ui` function.

This likely isn't ready to merge yet, just wanted to get the pull request going and get eyes on the last issue I'm having with it - for some reason an error is generated when line 33 is uncommented - this works in the non-mutable `ui_readonly`, but for some reason in the mutable version the compiler complains about a `self` borrow escaping the scope of the function. Not sure why, still looking into that.

One more thing I wanted to ask about: for my purposes, I'm interested in showing all available assets, not just loaded ones. I'd probably go about implementing that using `AssetReader` to get all available asset paths. It'd probably be a bit more complex but a lot more powerful as an editor tool. Is that something you'd be interested in rolling into this PR?

Thanks! :)