### PR TITLE
Added more types for default registration when using without `bevy_render`

### DIFF
--- a/crates/bevy-inspector-egui/src/lib.rs
+++ b/crates/bevy-inspector-egui/src/lib.rs
@@ -158,7 +158,7 @@ impl bevy_app::Plugin for DefaultInspectorConfigPlugin {
             return;
         }
 
-        // Defensively register stuff since bevy only registers glam types used by other structs internally
+        // Defensively register stuff since bevy only registers glam, color types used by other structs internally
         app.register_type::<bevy_math::IVec2>()
             .register_type::<bevy_math::IVec3>()
             .register_type::<bevy_math::IVec4>()
@@ -190,7 +190,9 @@ impl bevy_app::Plugin for DefaultInspectorConfigPlugin {
             .register_type::<bevy_math::Mat4>()
             .register_type::<bevy_math::DQuat>()
             .register_type::<bevy_math::Quat>()
-            .register_type::<bevy_math::Rect>();
+            .register_type::<bevy_math::Rect>()
+            .register_type::<bevy_color::Color>()
+            .register_type::<core::ops::Range<f32>>();
 
         let type_registry = app.world().resource::<bevy_ecs::prelude::AppTypeRegistry>();
         let mut type_registry = type_registry.write();


### PR DESCRIPTION
Fixes the following crash:

```shell
2024-07-07T11:24:51.915263Z  WARN bevy_inspector_egui::inspector_options::default_options: Attempting to set default inspector options for bevy_color::srgba::Srgba, but it wasn't registered in the type registry.
2024-07-07T11:24:51.915282Z  WARN bevy_inspector_egui::inspector_options::default_options: Attempting to set default inspector options for bevy_color::linear_rgba::LinearRgba, but it wasn't registered in the type registry.
2024-07-07T11:24:51.915284Z  WARN bevy_inspector_egui::inspector_options::default_options: Attempting to set default inspector options for bevy_color::hsla::Hsla, but it wasn't registered in the type registry.
2024-07-07T11:24:51.915286Z  WARN bevy_inspector_egui::inspector_options::default_options: Attempting to set default inspector options for bevy_color::hsva::Hsva, but it wasn't registered in the type registry.
2024-07-07T11:24:51.915288Z  WARN bevy_inspector_egui::inspector_options::default_options: Attempting to set default inspector options for bevy_color::hwba::Hwba, but it wasn't registered in the type registry.
2024-07-07T11:24:51.915371Z  WARN bevy_inspector_egui::inspector_options::default_options: Attempting to set default inspector options for bevy_color::laba::Laba, but it wasn't registered in the type registry.
2024-07-07T11:24:51.915374Z  WARN bevy_inspector_egui::inspector_options::default_options: Attempting to set default inspector options for bevy_color::lcha::Lcha, but it wasn't registered in the type registry.
2024-07-07T11:24:51.915376Z  WARN bevy_inspector_egui::inspector_options::default_options: Attempting to set default inspector options for bevy_color::oklaba::Oklaba, but it wasn't registered in the type registry.
2024-07-07T11:24:51.915390Z  WARN bevy_inspector_egui::inspector_options::default_options: Attempting to set default inspector options for bevy_color::oklcha::Oklcha, but it wasn't registered in the type registry.
2024-07-07T11:24:51.915454Z  WARN bevy_inspector_egui::inspector_options::default_options: Attempting to set default inspector options for bevy_color::xyza::Xyza, but it wasn't registered in the type registry.
thread 'main' panicked at /Users/swoorup.joshi/.cargo/registry/src/index.crates.io-6f17d22bba15001f/bevy_reflect-0.14.0/src/type_registry.rs:260:13:
attempted to call `TypeRegistry::register_type_data` for type `core::ops::Range<f32>` with data `bevy_inspector_egui::inspector_egui_impls::InspectorEguiImpl` without registering `core::ops::Range<f32>` first
```