### PR TITLE
Fix render layer inspector

### DIFF
--- a/crates/bevy-inspector-egui/src/inspector_egui_impls/bevy_impls.rs
+++ b/crates/bevy-inspector-egui/src/inspector_egui_impls/bevy_impls.rs
@@ -292,13 +292,9 @@ impl InspectorPrimitive for RenderLayers {
     fn ui(&mut self, ui: &mut egui::Ui, _: &dyn Any, id: egui::Id, _: InspectorUi<'_, '_>) -> bool {
         let mut new_value = None;
         egui::Grid::new(id).num_columns(2).show(ui, |ui| {
-            let layer_count = self.iter().count();
             for layer in self.iter() {
                 let mut layer_copy = layer;
-                if ui
-                    .add(egui::DragValue::new(&mut layer_copy).range(0..=layer_count - 1))
-                    .changed()
-                {
+                if ui.add(egui::DragValue::new(&mut layer_copy)).changed() {
                     new_value = Some(self.clone().without(layer).with(layer_copy));
                 }
 


### PR DESCRIPTION
The inspector was clamping the RenderLayers's values to the number of layers which is incorrect. There are no longer limitations on the maximum render layer value since bevy 0.14