### PR TITLE
manage_clipboard feature fix

### DIFF
--- a/crates/bevy-inspector-egui-derive/Cargo.toml
+++ b/crates/bevy-inspector-egui-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy-inspector-egui-derive"
-version = "0.25.0"
+version = "0.25.1"
 edition = "2021"
 repository = "https://github.com/jakobhellermann/bevy-inspector-egui/"
 readme = "README.md"

--- a/crates/bevy-inspector-egui/Cargo.toml
+++ b/crates/bevy-inspector-egui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy-inspector-egui"
-version = "0.25.0"
+version = "0.25.1"
 edition = "2021"
 repository = "https://github.com/jakobhellermann/bevy-inspector-egui/"
 readme = "README.md"
@@ -23,7 +23,7 @@ egui_open_url = ["bevy_egui/open_url"]
 highlight_changes = []
 
 [dependencies]
-bevy-inspector-egui-derive = { version = "0.25.0", path = "../bevy-inspector-egui-derive" }
+bevy-inspector-egui-derive = { version = "0.25.1", path = "../bevy-inspector-egui-derive" }
 bevy_app = { version = "0.14.0" }
 bevy_asset = { version = "0.14.0" }
 bevy_color = { version = "0.14.0" }

--- a/crates/bevy-inspector-egui/Cargo.toml
+++ b/crates/bevy-inspector-egui/Cargo.toml
@@ -16,8 +16,10 @@ categories = [
 ]
 
 [features]
-default = ["bevy_pbr", "bevy_render"]
+default = ["bevy_pbr", "bevy_render", "egui_clipboard", "egui_open_url"]
 bevy_render = ["dep:bevy_render", "dep:bevy_core_pipeline", "bevy_egui/render"]
+egui_clipboard = ["bevy_egui/manage_clipboard"]
+egui_open_url = ["bevy_egui/open_url"]
 highlight_changes = []
 
 [dependencies]
@@ -41,9 +43,7 @@ bevy_core_pipeline = { version = "0.14", optional = true }
 bevy_pbr = { version = "0.14", optional = true }
 
 egui = "0.28"
-bevy_egui = { version = "0.28", default-features = false, features = [
-    "manage_clipboard", "open_url"
-] }
+bevy_egui = { version = "0.28", default-features = false }
 
 bytemuck = "1.16.0"
 image = { version = "0.24", default-features = false }


### PR DESCRIPTION
Fixes #209

- This approach successfully solves the issue for me and lets me build for wasm
- I don't know what feature names we should use, e.g. if you want to expose to users of this crate the fact that the open URL and clipboard features are related to "egui", then the current prefix is good. If you want to make it agnostic we should ditch the `egui_` prefix
- I bumped the version to 0.25.1 to match crates.io—was there a publish to crates.io but no corresponding commit and tag in here?