### PR TITLE
Re-enable `InspectorEguiImpl` registrations for `Handle<Mesh>` and `Handle<Image>`

### DIFF
--- a/crates/bevy-inspector-egui/src/inspector_egui_impls/mod.rs
+++ b/crates/bevy-inspector-egui/src/inspector_egui_impls/mod.rs
@@ -312,8 +312,8 @@ pub fn register_bevy_impls(type_registry: &mut TypeRegistry) {
 
     #[cfg(feature = "bevy_render")] 
     {
-      // add_of_with_many::<bevy_asset::Handle<bevy_render::texture::Image>>(type_registry, many_unimplemented::<bevy_asset::Handle<bevy_render::texture::Image>>);
-      // add_of_with_many::<bevy_asset::Handle<bevy_render::mesh::Mesh>>(type_registry, many_unimplemented::<bevy_asset::Handle<bevy_render::mesh::Mesh>>);
+      add_of_with_many::<bevy_asset::Handle<bevy_render::texture::Image>>(type_registry, many_unimplemented::<bevy_asset::Handle<bevy_render::texture::Image>>);
+      add_of_with_many::<bevy_asset::Handle<bevy_render::mesh::Mesh>>(type_registry, many_unimplemented::<bevy_asset::Handle<bevy_render::mesh::Mesh>>);
       add::<bevy_render::view::RenderLayers>(type_registry);
     }
 }


### PR DESCRIPTION
Re-enable the default `InspectorEguiImpl` registrations for `Handle<Mesh>` and `Handle<Image>`.

| Before | After |
| ------ | ----- |
| <img width="873" alt="assets-before" src="https://github.com/user-attachments/assets/71335787-268c-43d0-b44d-b9047587a801"> | <img width="881" alt="assets-after" src="https://github.com/user-attachments/assets/7201f456-75f0-40b2-a885-8c8428247075"> |
