### PR TITLE
Add Observer to entity name associations

### DIFF
--- a/crates/bevy-inspector-egui/src/utils.rs
+++ b/crates/bevy-inspector-egui/src/utils.rs
@@ -69,6 +69,7 @@ pub mod guess_entity_name {
             ("bevy_ui::ui_node::Node", "Node"),
             ("bevy_asset::handle::Handle<bevy_pbr::pbr_material::StandardMaterial>", "Pbr Mesh"),
             ("bevy_window::window::Window", "Window"),
+            ("bevy_ecs::observer::runner::ObserverState", "Observer"),
         ];
 
         let type_names = archetype.components().filter_map(|id| {


### PR DESCRIPTION
The inspector now marks these as *Observer*.

<img width="387" alt="image" src="https://github.com/user-attachments/assets/2c1821a9-2d2b-4592-b4d0-da7f41e1b9f2">

You can search for them if you want:

<img width="373" alt="image" src="https://github.com/user-attachments/assets/1df13e39-ff5c-4646-b000-e68bb33de9ac">
