### PR TITLE
Minibuffer integration?

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,4 +3,4 @@ resolver = "2"
 members = ["crates/*"]
 
 [patch.crates-io]
-bevy_minibuffer = { path = "../bevy_minibuffer" }
+bevy_minibuffer = { git = "https://github.com/shanecelis/bevy_minibuffer.git" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,6 @@
 [workspace]
 resolver = "2"
 members = ["crates/*"]
+
+[patch.crates-io]
+bevy_minibuffer = { path = "../bevy_minibuffer" }

--- a/crates/bevy-inspector-egui/Cargo.toml
+++ b/crates/bevy-inspector-egui/Cargo.toml
@@ -27,6 +27,7 @@ bevy_render = ["dep:bevy_render", "dep:bevy_core_pipeline", "bevy_egui/render"]
 egui_clipboard = ["bevy_egui/manage_clipboard"]
 egui_open_url = ["bevy_egui/open_url"]
 highlight_changes = []
+minibuffer = ["dep:bevy_minibuffer", "dep:trie-rs"]
 
 [package.metadata.docs.rs]
 features = ["winit/x11"]
@@ -63,6 +64,8 @@ smallvec = "1.10"
 
 fuzzy-matcher = "0.3.7"
 disqualified = "1.0.0"
+bevy_minibuffer = { version = "0.2.0", optional = true }
+trie-rs = { version = "0.4.2", optional = true }
 
 [dev-dependencies]
 bevy = { version = "0.15.0", default-features = false, features = [
@@ -94,7 +97,7 @@ path = "examples/basic/custom_type_ui.rs"
 
 [[example]]
 name = "resource_inspector_manual"
-path = "examples/basic/resource_inspector_manual.rs"
+path = "examples/integrations/resource_inspector_manual.rs"
 
 [[example]]
 name = "resource_inspector"
@@ -127,6 +130,11 @@ path = "examples/integrations/egui_dock.rs"
 [[example]]
 name = "side_panel"
 path = "examples/integrations/side_panel.rs"
+
+[[example]]
+name = "minibuffer"
+path = "examples/integrations/minibuffer.rs"
+required-features = [ "minibuffer" ]
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(egui_dock_gizmo)'] }

--- a/crates/bevy-inspector-egui/Cargo.toml
+++ b/crates/bevy-inspector-egui/Cargo.toml
@@ -27,7 +27,7 @@ bevy_render = ["dep:bevy_render", "dep:bevy_core_pipeline", "bevy_egui/render"]
 egui_clipboard = ["bevy_egui/manage_clipboard"]
 egui_open_url = ["bevy_egui/open_url"]
 highlight_changes = []
-minibuffer = ["dep:bevy_minibuffer", "dep:trie-rs"]
+minibuffer = ["dep:bevy_minibuffer", "dep:trie-rs", "dep:keyseq"]
 
 [package.metadata.docs.rs]
 features = ["winit/x11"]
@@ -66,6 +66,7 @@ fuzzy-matcher = "0.3.7"
 disqualified = "1.0.0"
 bevy_minibuffer = { version = "0.2.0", optional = true }
 trie-rs = { version = "0.4.2", optional = true }
+keyseq = { version = "0.5.0", optional = true, features = [ "bevy" ] }
 
 [dev-dependencies]
 bevy = { version = "0.15.0", default-features = false, features = [

--- a/crates/bevy-inspector-egui/Cargo.toml
+++ b/crates/bevy-inspector-egui/Cargo.toml
@@ -98,7 +98,7 @@ path = "examples/basic/custom_type_ui.rs"
 
 [[example]]
 name = "resource_inspector_manual"
-path = "examples/integrations/resource_inspector_manual.rs"
+path = "examples/basic/resource_inspector_manual.rs"
 
 [[example]]
 name = "resource_inspector"

--- a/crates/bevy-inspector-egui/examples/integrations/minibuffer.rs
+++ b/crates/bevy-inspector-egui/examples/integrations/minibuffer.rs
@@ -3,6 +3,14 @@ use bevy_inspector_egui::minibuffer;
 use bevy_inspector_egui::prelude::*;
 use bevy_minibuffer::prelude::*;
 
+#[derive(States, Default, Debug, Clone, Eq, PartialEq, Hash, Reflect)]
+enum AppState {
+    #[default]
+    A,
+    B,
+    C,
+}
+
 #[derive(Reflect, Resource, Default, InspectorOptions)]
 #[reflect(Resource, InspectorOptions)]
 struct Configuration {
@@ -22,20 +30,67 @@ struct Settings {
 fn main() {
     App::new()
         .add_plugins((DefaultPlugins,
-                      MinibufferPlugins,
-                      minibuffer::ResourceInspectorPlugins::default()
-                      .add::<Configuration>()
-                      .add::<Settings>()
-        ))
+                      MinibufferPlugins))
+        .init_state::<AppState>()
+        .register_type::<AppState>()
         .init_resource::<Configuration>()
         .register_type::<Configuration>()
         .init_resource::<Settings>()
         .register_type::<Settings>()
         .add_acts((BasicActs::default(),
                    minibuffer::InspectorActs::default(),
+                   minibuffer::ResourceInspectorActs::default()
+                    .add::<Configuration>()
+                    .add::<Settings>(),
+                   minibuffer::StateInspectorActs::default()
+                   .add::<AppState>(),
+                   minibuffer::AssetInspectorActs::default()
+                   .add::<StandardMaterial>(),
         ))
-        .add_systems(Startup, |mut commands: Commands| {
-            commands.spawn(Camera2d);
-        })
+        .add_systems(Startup, setup)
+        .add_systems(OnEnter(AppState::A), set_color(Srgba::hex("8ecae6").unwrap()))
+        .add_systems(OnEnter(AppState::B), set_color(Srgba::hex("d5a220").unwrap()))
+        .add_systems(OnEnter(AppState::C), set_color(Srgba::hex("d2660f").unwrap()))
         .run();
+}
+
+/// set up a simple 3D scene
+fn setup(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+) {
+    // plane
+    commands.spawn((
+        Mesh3d(meshes.add(Plane3d::default().mesh().size(5.0, 5.0))),
+        MeshMaterial3d(materials.add(Color::srgb(0.3, 0.5, 0.3))),
+        Transform::from_xyz(0.0, 0.0, 1.0),
+    ));
+    // cube
+    commands.spawn((
+        Mesh3d(meshes.add(Cuboid::new(1.0, 1.0, 1.0))),
+        MeshMaterial3d(materials.add(Color::srgb(0.8, 0.7, 0.6))),
+        Transform::from_xyz(0.0, 0.5, 0.0),
+    ));
+    // light
+    commands.spawn((
+        PointLight {
+            intensity: 2_000_000.0,
+            shadows_enabled: true,
+            ..default()
+        },
+        Transform::from_xyz(4.0, 8.0, 4.0),
+    ));
+    // camera
+    commands.spawn((
+        Camera3d::default(),
+        Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
+    ));
+}
+
+fn set_color(color: impl Into<Color>) -> impl Fn(Commands) {
+    let color = color.into();
+    move |mut commands: Commands| {
+        commands.insert_resource(ClearColor(color))
+    }
 }

--- a/crates/bevy-inspector-egui/examples/integrations/minibuffer.rs
+++ b/crates/bevy-inspector-egui/examples/integrations/minibuffer.rs
@@ -1,0 +1,41 @@
+use bevy::prelude::*;
+use bevy_inspector_egui::minibuffer;
+use bevy_inspector_egui::prelude::*;
+use bevy_minibuffer::prelude::*;
+
+#[derive(Reflect, Resource, Default, InspectorOptions)]
+#[reflect(Resource, InspectorOptions)]
+struct Configuration {
+    name: String,
+    #[inspector(min = 0.0, max = 1.0)]
+    option: f32,
+}
+
+#[derive(Reflect, Resource, Default, InspectorOptions)]
+#[reflect(Resource, InspectorOptions)]
+struct Settings {
+    name: String,
+    #[inspector(min = 0.0, max = 1.0)]
+    option: f32,
+}
+
+fn main() {
+    App::new()
+        .add_plugins((DefaultPlugins,
+                      MinibufferPlugins,
+                      minibuffer::ResourceInspectorPlugins::default()
+                      .add::<Configuration>()
+                      .add::<Settings>()
+        ))
+        .init_resource::<Configuration>()
+        .register_type::<Configuration>()
+        .init_resource::<Settings>()
+        .register_type::<Settings>()
+        .add_acts((BasicActs::default(),
+                   minibuffer::InspectorActs::default(),
+        ))
+        .add_systems(Startup, |mut commands: Commands| {
+            commands.spawn(Camera2d);
+        })
+        .run();
+}

--- a/crates/bevy-inspector-egui/examples/integrations/minibuffer.rs
+++ b/crates/bevy-inspector-egui/examples/integrations/minibuffer.rs
@@ -53,10 +53,8 @@ fn main() {
             minibuffer::ResourceInspectorActs::default()
                 .add::<Configuration>()
                 .add::<Settings>(),
-            minibuffer::StateInspectorActs::default()
-                .add::<AppState>(),
-            minibuffer::AssetInspectorActs::default()
-                .add::<StandardMaterial>(),
+            minibuffer::StateInspectorActs::default().add::<AppState>(),
+            minibuffer::AssetInspectorActs::default().add::<StandardMaterial>(),
             minibuffer::FilterQueryInspectorActs::default()
                 .add::<With<Transform>>()
                 .add::<With<Mesh3d>>(),

--- a/crates/bevy-inspector-egui/examples/integrations/minibuffer.rs
+++ b/crates/bevy-inspector-egui/examples/integrations/minibuffer.rs
@@ -46,6 +46,10 @@ fn main() {
                    .add::<AppState>(),
                    minibuffer::AssetInspectorActs::default()
                    .add::<StandardMaterial>(),
+                   minibuffer::FilterQueryInspectorActs::default()
+                   .add::<With<Transform>>()
+                   .add::<With<Mesh3d>>()
+                   ,
         ))
         .add_systems(Startup, setup)
         .add_systems(OnEnter(AppState::A), set_color(Srgba::hex("8ecae6").unwrap()))

--- a/crates/bevy-inspector-egui/examples/integrations/minibuffer.rs
+++ b/crates/bevy-inspector-egui/examples/integrations/minibuffer.rs
@@ -1,3 +1,14 @@
+//! Demo of bevy_minibuffer integration with bevy-inspector-egui.
+//!
+//! This composite demo synthesizes several bevy-inspector-egui demos to show
+//! how the various inspectors can be made available via minibuffer.
+//!
+//! The inspector commands are:
+//! - world_inspector
+//! - resource_inspector
+//! - asset_inspector
+//! - state_inspector
+//! - filter_query_inspector
 use bevy::prelude::*;
 use bevy_inspector_egui::minibuffer;
 use bevy_inspector_egui::prelude::*;
@@ -29,32 +40,40 @@ struct Settings {
 
 fn main() {
     App::new()
-        .add_plugins((DefaultPlugins,
-                      MinibufferPlugins))
+        .add_plugins((DefaultPlugins, MinibufferPlugins))
         .init_state::<AppState>()
         .register_type::<AppState>()
         .init_resource::<Configuration>()
         .register_type::<Configuration>()
         .init_resource::<Settings>()
         .register_type::<Settings>()
-        .add_acts((BasicActs::default(),
-                   minibuffer::WorldInspectorActs::default(),
-                   minibuffer::ResourceInspectorActs::default()
-                    .add::<Configuration>()
-                    .add::<Settings>(),
-                   minibuffer::StateInspectorActs::default()
-                   .add::<AppState>(),
-                   minibuffer::AssetInspectorActs::default()
-                   .add::<StandardMaterial>(),
-                   minibuffer::FilterQueryInspectorActs::default()
-                   .add::<With<Transform>>()
-                   .add::<With<Mesh3d>>()
-                   ,
+        .add_acts((
+            BasicActs::default(),
+            minibuffer::WorldInspectorActs::default(),
+            minibuffer::ResourceInspectorActs::default()
+                .add::<Configuration>()
+                .add::<Settings>(),
+            minibuffer::StateInspectorActs::default()
+                .add::<AppState>(),
+            minibuffer::AssetInspectorActs::default()
+                .add::<StandardMaterial>(),
+            minibuffer::FilterQueryInspectorActs::default()
+                .add::<With<Transform>>()
+                .add::<With<Mesh3d>>(),
         ))
         .add_systems(Startup, setup)
-        .add_systems(OnEnter(AppState::A), set_color(Srgba::hex("8ecae6").unwrap()))
-        .add_systems(OnEnter(AppState::B), set_color(Srgba::hex("d5a220").unwrap()))
-        .add_systems(OnEnter(AppState::C), set_color(Srgba::hex("d2660f").unwrap()))
+        .add_systems(
+            OnEnter(AppState::A),
+            set_color(Srgba::hex("8ecae6").unwrap()),
+        )
+        .add_systems(
+            OnEnter(AppState::B),
+            set_color(Srgba::hex("d5a220").unwrap()),
+        )
+        .add_systems(
+            OnEnter(AppState::C),
+            set_color(Srgba::hex("d2660f").unwrap()),
+        )
         .run();
 }
 
@@ -63,6 +82,7 @@ fn setup(
     mut commands: Commands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
+    mut minibuffer: Minibuffer,
 ) {
     // plane
     commands.spawn((
@@ -90,11 +110,12 @@ fn setup(
         Camera3d::default(),
         Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
     ));
+
+    minibuffer.message("Type ':world Tab Return' to see the world inspector. Then type ': Tab' to see the other inspectors.");
+    minibuffer.set_visible(true);
 }
 
 fn set_color(color: impl Into<Color>) -> impl Fn(Commands) {
     let color = color.into();
-    move |mut commands: Commands| {
-        commands.insert_resource(ClearColor(color))
-    }
+    move |mut commands: Commands| commands.insert_resource(ClearColor(color))
 }

--- a/crates/bevy-inspector-egui/examples/integrations/minibuffer.rs
+++ b/crates/bevy-inspector-egui/examples/integrations/minibuffer.rs
@@ -38,7 +38,7 @@ fn main() {
         .init_resource::<Settings>()
         .register_type::<Settings>()
         .add_acts((BasicActs::default(),
-                   minibuffer::InspectorActs::default(),
+                   minibuffer::WorldInspectorActs::default(),
                    minibuffer::ResourceInspectorActs::default()
                     .add::<Configuration>()
                     .add::<Settings>(),

--- a/crates/bevy-inspector-egui/src/lib.rs
+++ b/crates/bevy-inspector-egui/src/lib.rs
@@ -150,6 +150,9 @@ mod utils;
 pub use bevy_egui;
 pub use egui;
 
+#[cfg(feature = "minibuffer")]
+pub mod minibuffer;
+
 /// [`bevy_app::Plugin`] used to register default [`struct@InspectorOptions`] and [`InspectorEguiImpl`](crate::inspector_egui_impls::InspectorEguiImpl)s
 pub struct DefaultInspectorConfigPlugin;
 impl bevy_app::Plugin for DefaultInspectorConfigPlugin {

--- a/crates/bevy-inspector-egui/src/minibuffer.rs
+++ b/crates/bevy-inspector-egui/src/minibuffer.rs
@@ -1,0 +1,151 @@
+use bevy_app::{App, Plugin, PluginGroup, PluginGroupBuilder};
+use bevy_state::prelude::in_state;
+use bevy_minibuffer::{prelude::*, prompt::PromptState};
+use crate::{
+    quick::{WorldInspectorPlugin, ResourceInspectorPlugin},
+    utils::pretty_type_name,
+};
+use bevy_ecs::{prelude::{Res, ResMut, Resource, World, Trigger}, schedule::Condition};
+use bevy_state::app::AppExtStates;
+use bevy_state::prelude::{State, NextState, States};
+use bevy_egui::EguiContext;
+use bevy_reflect::Reflect;
+use trie_rs::map::Trie;
+
+/// Is the prompt visible?
+#[derive(Debug, Clone, Copy, Default, Eq, PartialEq, Hash, States, Reflect)]
+pub enum WorldInspectorState {
+    /// Invisible
+    #[default]
+    Invisible,
+    /// Visible
+    Visible,
+}
+
+#[derive(Resource)]
+pub struct ResourceInspectors {
+    names: Trie<u8, usize>,
+    visible: Vec<bool>,
+}
+
+pub struct ResourceInspectorPlugins {
+    plugins: Option<PluginGroupBuilder>,
+    resource_names: Vec<String>,
+}
+
+impl ResourceInspectorPlugins {
+    pub fn add<R: Resource + Reflect>(mut self) -> Self {
+        let index = self.resource_names.len();
+        self.resource_names.push(pretty_type_name::<R>());
+        self.add_plugin(resource_inspector_plugin::<R>(index));
+        self
+    }
+
+    fn add_plugin<T: Plugin>(&mut self, plugin: T) {
+        let builder = self.plugins.take().expect("plugin builder");
+        self.plugins = Some(builder.add(plugin));
+    }
+}
+
+impl Default for ResourceInspectorPlugins {
+    fn default() -> Self {
+        Self {
+            plugins: Some(PluginGroupBuilder::start::<Self>()),
+            resource_names: vec![],
+        }
+    }
+}
+
+impl PluginGroup for ResourceInspectorPlugins {
+    fn build(mut self) -> PluginGroupBuilder {
+        let builder = self.plugins.take().expect("plugin builder");
+        // let resource_names = self.resource_names.drain(..);
+        builder.add(move |app: &mut App| {
+            let count = self.resource_names.len();
+            let trie = Trie::from_iter(self.resource_names.clone().into_iter().enumerate().map(|(index, name)| (name, index)));
+            app.insert_resource(ResourceInspectors {
+                names: trie,
+                visible: vec![false; count],
+            });
+        })
+    }
+}
+
+pub struct InspectorActs {
+    pub acts: Acts,
+}
+
+fn resource_visible(index: usize) -> impl Fn(Res<ResourceInspectors>) -> bool {
+    move |inspectors: Res<ResourceInspectors>| {
+        inspectors.visible.get(index).copied().unwrap_or(false)
+    }
+}
+
+fn resource_inspector_plugin<R: Resource + Reflect>(index: usize) -> impl Fn(&mut App) {
+    move |app: &mut App| {
+        app.add_plugins(ResourceInspectorPlugin::<R>::default()
+                    .run_if(in_state(PromptState::Visible).and(resource_visible(index)))
+        );
+    }
+}
+
+impl InspectorActs {
+}
+
+impl ActsPlugin for InspectorActs {
+    fn acts(&self) -> &Acts {
+        &self.acts
+    }
+    fn acts_mut(&mut self) -> &mut Acts {
+        &mut self.acts
+    }
+}
+
+fn world_inspector(state: Res<State<WorldInspectorState>>,
+                   mut next_state: ResMut<NextState<WorldInspectorState>>,
+                   mut minibuffer: Minibuffer) {
+    use WorldInspectorState::*;
+    let (state, msg) = match state.get() {
+        Invisible => (Visible, "Show world inspector"),
+        Visible => (Invisible, "Hide world inspector"),
+    };
+    next_state.set(state);
+    minibuffer.message(msg);
+}
+
+fn resource_inspector(resources: Option<Res<ResourceInspectors>>,
+                      mut minibuffer: Minibuffer) {
+    if let Some(ref resources) = resources {
+        minibuffer.prompt_map("resource: ", resources.names.clone())
+            .observe(|mut trigger: Trigger<Completed<usize>>,
+                     mut resources: ResMut<ResourceInspectors>,
+                     mut minibuffer: Minibuffer| {
+                         if let Ok(index) = trigger.event_mut().take_result().unwrap() {
+                             resources.visible[index] = !resources.visible[index];
+                         }
+            });
+    } else {
+        minibuffer.message("No resource inspectors available.");
+    }
+}
+
+impl Default for InspectorActs {
+    fn default() -> Self {
+        Self {
+            acts: Acts::new([
+                Act::new(world_inspector),
+                Act::new(resource_inspector)
+                ]),
+        }
+    }
+}
+
+impl Plugin for InspectorActs {
+    fn build(&self, app: &mut App) {
+
+        app.add_plugins(WorldInspectorPlugin::default().run_if(in_state(PromptState::Visible).and(in_state(WorldInspectorState::Visible))))
+            .init_state::<WorldInspectorState>()
+            ;
+        self.warn_on_unused_acts();
+    }
+}

--- a/crates/bevy-inspector-egui/src/minibuffer/asset_inspector.rs
+++ b/crates/bevy-inspector-egui/src/minibuffer/asset_inspector.rs
@@ -1,3 +1,21 @@
+//! # asset_inspector act
+//!
+//! ## Usage
+//!
+//! ```no_run
+//! use bevy::prelude::*;
+//! use bevy_minibuffer::prelude::*;
+//! use bevy_inspector_egui::minibuffer;
+//! fn plugin(app: &mut App) {
+//!     app
+//!         .add_plugins(MinibufferPlugins)
+//!         .add_acts((
+//!             BasicActs::default(),
+//!             minibuffer::AssetInspectorActs::default()
+//!                 .add::<StandardMaterial>()
+//!         ));
+//! }
+//! ```
 use crate::{
     minibuffer::{InspectorPlugins, Inspectors},
     quick::AssetInspectorPlugin,
@@ -13,6 +31,7 @@ use bevy_minibuffer::{prelude::*, prompt::PromptState};
 use bevy_reflect::Reflect;
 use bevy_state::prelude::in_state;
 
+/// Add 'asset_inspector' act which toggles the visibility of added asset inspectors.
 pub struct AssetInspectorActs {
     plugins: InspectorPlugins<Self>,
     acts: Acts,
@@ -29,6 +48,7 @@ impl ActsPluginGroup for AssetInspectorActs {
 }
 
 impl AssetInspectorActs {
+    /// Add an asset to be shown when prompted.
     pub fn add<A: Asset + Reflect>(mut self) -> Self {
         self.plugins
             .add_inspector(pretty_type_name::<A>(), Self::asset_inspector_plugin::<A>);

--- a/crates/bevy-inspector-egui/src/minibuffer/asset_inspector.rs
+++ b/crates/bevy-inspector-egui/src/minibuffer/asset_inspector.rs
@@ -97,7 +97,8 @@ fn asset_inspector(assets: Res<Inspectors<AssetInspectorActs>>, mut minibuffer: 
 impl PluginGroup for AssetInspectorActs {
     fn build(self) -> PluginGroupBuilder {
         self.warn_on_unused_acts();
-        self.plugins.warn_on_empty("No assets registered with `AssetInspectorActs`; consider adding some.");
+        self.plugins
+            .warn_on_empty("No assets registered with `AssetInspectorActs`; consider adding some.");
         self.plugins.build()
     }
 }

--- a/crates/bevy-inspector-egui/src/minibuffer/asset_inspector.rs
+++ b/crates/bevy-inspector-egui/src/minibuffer/asset_inspector.rs
@@ -1,0 +1,106 @@
+use bevy_app::{App, Plugin, PluginGroup, PluginGroupBuilder};
+use bevy_state::prelude::in_state;
+use bevy_minibuffer::{prelude::*, prompt::PromptState};
+use crate::{
+    quick::{WorldInspectorPlugin, AssetInspectorPlugin},
+    utils::pretty_type_name,
+};
+use bevy_asset::Asset;
+use bevy_ecs::{prelude::{Resource, Res, ResMut, World, Trigger}, schedule::Condition};
+use bevy_state::app::AppExtStates;
+use bevy_state::prelude::{State, NextState, States};
+use bevy_egui::EguiContext;
+use bevy_reflect::Reflect;
+use trie_rs::map::Trie;
+
+#[derive(Resource)]
+pub(crate) struct AssetInspectors {
+    pub(crate) names: Trie<u8, usize>,
+    pub(crate) visible: Vec<bool>,
+}
+
+pub struct AssetInspectorActs {
+    plugins: Option<PluginGroupBuilder>,
+    asset_names: Vec<String>,
+    acts: Acts,
+}
+
+impl ActsPluginGroup for AssetInspectorActs {
+    fn acts(&self) -> &Acts {
+        &self.acts
+    }
+
+    fn acts_mut(&mut self) -> &mut Acts {
+        &mut self.acts
+    }
+}
+
+impl AssetInspectorActs {
+    pub fn add<R: Asset + Reflect>(mut self) -> Self {
+        let index = self.asset_names.len();
+        self.asset_names.push(pretty_type_name::<R>());
+        self.add_plugin(asset_inspector_plugin::<R>(index));
+        self
+    }
+
+    fn add_plugin<T: Plugin>(&mut self, plugin: T) {
+        let builder = self.plugins.take().expect("plugin builder");
+        self.plugins = Some(builder.add(plugin));
+    }
+}
+
+impl Default for AssetInspectorActs {
+    fn default() -> Self {
+        Self {
+            plugins: Some(PluginGroupBuilder::start::<Self>()),
+            asset_names: vec![],
+            acts: Acts::new([Act::new(asset_inspector)]),
+        }
+    }
+}
+
+fn asset_inspector(assets: Res<AssetInspectors>,
+                   mut minibuffer: Minibuffer) {
+    if !assets.visible.is_empty() {
+        minibuffer.prompt_map("asset: ", assets.names.clone())
+            .observe(|mut trigger: Trigger<Completed<usize>>,
+                     mut assets: ResMut<AssetInspectors>,
+                     mut minibuffer: Minibuffer| {
+                         if let Ok(index) = trigger.event_mut().take_result().unwrap() {
+                             assets.visible[index] = !assets.visible[index];
+                         }
+            });
+    } else {
+        minibuffer.message("No assets registered.");
+    }
+}
+
+
+impl PluginGroup for AssetInspectorActs {
+    fn build(mut self) -> PluginGroupBuilder {
+        let builder = self.plugins.take().expect("plugin builder");
+        self.warn_on_unused_acts();
+        builder.add(move |app: &mut App| {
+            let count = self.asset_names.len();
+            let trie = Trie::from_iter(self.asset_names.clone().into_iter().enumerate().map(|(index, name)| (name, index)));
+            app.insert_resource(AssetInspectors {
+                names: trie,
+                visible: vec![false; count],
+            });
+        })
+    }
+}
+
+fn asset_visible(index: usize) -> impl Fn(Res<AssetInspectors>) -> bool {
+    move |inspectors: Res<AssetInspectors>| {
+        inspectors.visible.get(index).copied().unwrap_or(false)
+    }
+}
+
+fn asset_inspector_plugin<A: Asset + Reflect>(index: usize) -> impl Fn(&mut App) {
+    move |app: &mut App| {
+        app.add_plugins(AssetInspectorPlugin::<A>::default()
+                    .run_if(in_state(PromptState::Visible).and(asset_visible(index)))
+        );
+    }
+}

--- a/crates/bevy-inspector-egui/src/minibuffer/asset_inspector.rs
+++ b/crates/bevy-inspector-egui/src/minibuffer/asset_inspector.rs
@@ -1,18 +1,17 @@
-use bevy_app::{App, Plugin, PluginGroup, PluginGroupBuilder};
-use bevy_state::prelude::in_state;
-use bevy_minibuffer::{prelude::*, prompt::PromptState};
 use crate::{
-    quick::{WorldInspectorPlugin, AssetInspectorPlugin},
+    minibuffer::{InspectorPlugins, Inspectors},
+    quick::AssetInspectorPlugin,
     utils::pretty_type_name,
-    minibuffer::{Inspectors, InspectorPlugins},
 };
+use bevy_app::{PluginGroup, PluginGroupBuilder};
 use bevy_asset::Asset;
-use bevy_ecs::{prelude::{Resource, Res, ResMut, World, Trigger}, schedule::Condition};
-use bevy_state::app::AppExtStates;
-use bevy_state::prelude::{State, NextState, States};
-use bevy_egui::EguiContext;
+use bevy_ecs::{
+    prelude::{Res, ResMut, Trigger},
+    schedule::Condition,
+};
+use bevy_minibuffer::{prelude::*, prompt::PromptState};
 use bevy_reflect::Reflect;
-use trie_rs::map::Trie;
+use bevy_state::prelude::in_state;
 
 pub struct AssetInspectorActs {
     plugins: InspectorPlugins<Self>,
@@ -31,13 +30,19 @@ impl ActsPluginGroup for AssetInspectorActs {
 
 impl AssetInspectorActs {
     pub fn add<A: Asset + Reflect>(mut self) -> Self {
-        self.plugins.add_inspector(pretty_type_name::<A>(), Self::asset_inspector_plugin::<A>);
+        self.plugins
+            .add_inspector(pretty_type_name::<A>(), Self::asset_inspector_plugin::<A>);
         self
     }
 
-    fn asset_inspector_plugin<A: Asset + Reflect>(index: usize, inspector_plugins: &mut InspectorPlugins<Self>) {
-        inspector_plugins.add_plugin(AssetInspectorPlugin::<A>::default()
-                                     .run_if(in_state(PromptState::Visible).and(InspectorPlugins::<Self>::visible(index)))
+    fn asset_inspector_plugin<A: Asset + Reflect>(
+        index: usize,
+        inspector_plugins: &mut InspectorPlugins<Self>,
+    ) {
+        inspector_plugins.add_plugin(
+            AssetInspectorPlugin::<A>::default().run_if(
+                in_state(PromptState::Visible).and(InspectorPlugins::<Self>::visible(index)),
+            ),
         );
     }
 }
@@ -51,26 +56,26 @@ impl Default for AssetInspectorActs {
     }
 }
 
-fn asset_inspector(assets: Res<Inspectors<AssetInspectorActs>>,
-                   mut minibuffer: Minibuffer) {
+fn asset_inspector(assets: Res<Inspectors<AssetInspectorActs>>, mut minibuffer: Minibuffer) {
     if !assets.visible.is_empty() {
-        minibuffer.prompt_map("asset: ", assets.names.clone())
-            .observe(|mut trigger: Trigger<Completed<usize>>,
-                     mut assets: ResMut<Inspectors<AssetInspectorActs>>,
-                     mut minibuffer: Minibuffer| {
-                         if let Ok(index) = trigger.event_mut().take_result().unwrap() {
-                             assets.visible[index] = !assets.visible[index];
-                         }
-            });
+        minibuffer
+            .prompt_map("asset: ", assets.names.clone())
+            .observe(
+                |mut trigger: Trigger<Completed<usize>>,
+                 mut assets: ResMut<Inspectors<AssetInspectorActs>>| {
+                    if let Ok(index) = trigger.event_mut().take_result().unwrap() {
+                        assets.visible[index] = !assets.visible[index];
+                    }
+                },
+            );
     } else {
         minibuffer.message("No assets registered.");
     }
 }
 
 impl PluginGroup for AssetInspectorActs {
-    fn build(mut self) -> PluginGroupBuilder {
+    fn build(self) -> PluginGroupBuilder {
         self.warn_on_unused_acts();
         self.plugins.build()
     }
 }
-

--- a/crates/bevy-inspector-egui/src/minibuffer/asset_inspector.rs
+++ b/crates/bevy-inspector-egui/src/minibuffer/asset_inspector.rs
@@ -1,21 +1,3 @@
-//! # asset_inspector act
-//!
-//! ## Usage
-//!
-//! ```no_run
-//! use bevy::prelude::*;
-//! use bevy_minibuffer::prelude::*;
-//! use bevy_inspector_egui::minibuffer;
-//! fn plugin(app: &mut App) {
-//!     app
-//!         .add_plugins(MinibufferPlugins)
-//!         .add_acts((
-//!             BasicActs::default(),
-//!             minibuffer::AssetInspectorActs::default()
-//!                 .add::<StandardMaterial>()
-//!         ));
-//! }
-//! ```
 use crate::{
     minibuffer::{InspectorPlugins, Inspectors},
     quick::AssetInspectorPlugin,
@@ -31,7 +13,26 @@ use bevy_minibuffer::{prelude::*, prompt::PromptState};
 use bevy_reflect::Reflect;
 use bevy_state::prelude::in_state;
 
-/// Add 'asset_inspector' act which toggles the visibility of added asset inspectors.
+/// ## Adds the 'asset_inspector' act
+///
+/// This act toggles the visibility of added asset inspectors.
+///
+/// ## Usage
+///
+/// ```no_run
+/// use bevy::prelude::*;
+/// use bevy_minibuffer::prelude::*;
+/// use bevy_inspector_egui::minibuffer;
+/// fn plugin(app: &mut App) {
+///     app
+///         .add_plugins(MinibufferPlugins)
+///         .add_acts((
+///             BasicActs::default(),
+///             minibuffer::AssetInspectorActs::default()
+///                 .add::<StandardMaterial>()
+///         ));
+/// }
+/// ```
 pub struct AssetInspectorActs {
     plugins: InspectorPlugins<Self>,
     acts: Acts,
@@ -96,6 +97,7 @@ fn asset_inspector(assets: Res<Inspectors<AssetInspectorActs>>, mut minibuffer: 
 impl PluginGroup for AssetInspectorActs {
     fn build(self) -> PluginGroupBuilder {
         self.warn_on_unused_acts();
+        self.plugins.warn_on_empty("No assets registered with `AssetInspectorActs`; consider adding some.");
         self.plugins.build()
     }
 }

--- a/crates/bevy-inspector-egui/src/minibuffer/filter_query_inspector.rs
+++ b/crates/bevy-inspector-egui/src/minibuffer/filter_query_inspector.rs
@@ -101,7 +101,9 @@ fn filter_query_inspector(
 impl PluginGroup for FilterQueryInspectorActs {
     fn build(self) -> PluginGroupBuilder {
         self.warn_on_unused_acts();
-        self.plugins.warn_on_empty("No filter queries registered with `FilterQueryInspectorActs`; consider adding some.");
+        self.plugins.warn_on_empty(
+            "No filter queries registered with `FilterQueryInspectorActs`; consider adding some.",
+        );
         self.plugins.build()
     }
 }

--- a/crates/bevy-inspector-egui/src/minibuffer/filter_query_inspector.rs
+++ b/crates/bevy-inspector-egui/src/minibuffer/filter_query_inspector.rs
@@ -2,24 +2,24 @@ use bevy_app::{App, Plugin, PluginGroup, PluginGroupBuilder};
 use bevy_state::prelude::in_state;
 use bevy_minibuffer::{prelude::*, prompt::PromptState};
 use crate::{
-    quick::{WorldInspectorPlugin, AssetInspectorPlugin},
+    quick::{WorldInspectorPlugin, AssetInspectorPlugin, FilterQueryInspectorPlugin},
     utils::pretty_type_name,
     minibuffer::{Inspectors, InspectorPlugins},
 };
 use bevy_asset::Asset;
-use bevy_ecs::{prelude::{Resource, Res, ResMut, World, Trigger}, schedule::Condition};
+use bevy_ecs::{prelude::{Resource, Res, ResMut, World, Trigger}, schedule::Condition, query::QueryFilter};
 use bevy_state::app::AppExtStates;
 use bevy_state::prelude::{State, NextState, States};
 use bevy_egui::EguiContext;
 use bevy_reflect::Reflect;
 use trie_rs::map::Trie;
 
-pub struct AssetInspectorActs {
+pub struct FilterQueryInspectorActs {
     plugins: InspectorPlugins<Self>,
     acts: Acts,
 }
 
-impl ActsPluginGroup for AssetInspectorActs {
+impl ActsPluginGroup for FilterQueryInspectorActs {
     fn acts(&self) -> &Acts {
         &self.acts
     }
@@ -29,48 +29,47 @@ impl ActsPluginGroup for AssetInspectorActs {
     }
 }
 
-impl AssetInspectorActs {
-    pub fn add<A: Asset + Reflect>(mut self) -> Self {
-        self.plugins.add_inspector(pretty_type_name::<A>(), Self::asset_inspector_plugin::<A>);
+impl FilterQueryInspectorActs {
+    pub fn add<A: QueryFilter + 'static>(mut self) -> Self {
+        self.plugins.add_inspector(pretty_type_name::<A>(), Self::filter_query_inspector_plugin::<A>);
         self
     }
 
-    fn asset_inspector_plugin<A: Asset + Reflect>(index: usize, inspector_plugins: &mut InspectorPlugins<Self>) {
-        inspector_plugins.add_plugin(AssetInspectorPlugin::<A>::default()
+    fn filter_query_inspector_plugin<A: QueryFilter + 'static>(index: usize, inspector_plugins: &mut InspectorPlugins<Self>) {
+        inspector_plugins.add_plugin(FilterQueryInspectorPlugin::<A>::default()
                                      .run_if(in_state(PromptState::Visible).and(InspectorPlugins::<Self>::visible(index)))
         );
     }
 }
 
-impl Default for AssetInspectorActs {
+impl Default for FilterQueryInspectorActs {
     fn default() -> Self {
         Self {
             plugins: InspectorPlugins::default(),
-            acts: Acts::new([Act::new(asset_inspector)]),
+            acts: Acts::new([Act::new(filter_query_inspector)]),
         }
     }
 }
 
-fn asset_inspector(assets: Res<Inspectors<AssetInspectorActs>>,
+fn filter_query_inspector(assets: Res<Inspectors<FilterQueryInspectorActs>>,
                    mut minibuffer: Minibuffer) {
     if !assets.visible.is_empty() {
-        minibuffer.prompt_map("asset: ", assets.names.clone())
+        minibuffer.prompt_map("filter query: ", assets.names.clone())
             .observe(|mut trigger: Trigger<Completed<usize>>,
-                     mut assets: ResMut<Inspectors<AssetInspectorActs>>,
+                     mut assets: ResMut<Inspectors<FilterQueryInspectorActs>>,
                      mut minibuffer: Minibuffer| {
                          if let Ok(index) = trigger.event_mut().take_result().unwrap() {
                              assets.visible[index] = !assets.visible[index];
                          }
             });
     } else {
-        minibuffer.message("No assets registered.");
+        minibuffer.message("No filter queries registered.");
     }
 }
 
-impl PluginGroup for AssetInspectorActs {
+impl PluginGroup for FilterQueryInspectorActs {
     fn build(mut self) -> PluginGroupBuilder {
         self.warn_on_unused_acts();
         self.plugins.build()
     }
 }
-

--- a/crates/bevy-inspector-egui/src/minibuffer/filter_query_inspector.rs
+++ b/crates/bevy-inspector-egui/src/minibuffer/filter_query_inspector.rs
@@ -1,22 +1,3 @@
-//! # filter_query_inspector act
-//!
-//! ## Usage
-//!
-//! ```no_run
-//! use bevy::prelude::*;
-//! use bevy_minibuffer::prelude::*;
-//! use bevy_inspector_egui::minibuffer;
-//! fn plugin(app: &mut App) {
-//!     app
-//!         .add_plugins(MinibufferPlugins)
-//!         .add_acts((
-//!             BasicActs::default(),
-//!             minibuffer::FilterQueryInspectorActs::default()
-//!                 .add::<With<Transform>>()
-//!                 .add::<With<Mesh3d>>()
-//!         ));
-//! }
-//! ```
 use crate::{
     minibuffer::{InspectorPlugins, Inspectors},
     quick::FilterQueryInspectorPlugin,
@@ -31,8 +12,27 @@ use bevy_ecs::{
 use bevy_minibuffer::{prelude::*, prompt::PromptState};
 use bevy_state::prelude::in_state;
 
-/// Adds the 'filter_query_inspector' act which toggles the visibility of the
-/// added filter query inspectors.
+/// ## Adds the 'filter_query_inspector' act
+///
+/// This act toggles the visibility of the added filter query inspectors.
+///
+/// ## Usage
+///
+/// ```no_run
+/// use bevy::prelude::*;
+/// use bevy_minibuffer::prelude::*;
+/// use bevy_inspector_egui::minibuffer;
+/// fn plugin(app: &mut App) {
+///     app
+///         .add_plugins(MinibufferPlugins)
+///         .add_acts((
+///             BasicActs::default(),
+///             minibuffer::FilterQueryInspectorActs::default()
+///                 .add::<With<Transform>>()
+///                 .add::<With<Mesh3d>>()
+///         ));
+/// }
+/// ```
 pub struct FilterQueryInspectorActs {
     plugins: InspectorPlugins<Self>,
     acts: Acts,
@@ -101,6 +101,7 @@ fn filter_query_inspector(
 impl PluginGroup for FilterQueryInspectorActs {
     fn build(self) -> PluginGroupBuilder {
         self.warn_on_unused_acts();
+        self.plugins.warn_on_empty("No filter queries registered with `FilterQueryInspectorActs`; consider adding some.");
         self.plugins.build()
     }
 }

--- a/crates/bevy-inspector-egui/src/minibuffer/filter_query_inspector.rs
+++ b/crates/bevy-inspector-egui/src/minibuffer/filter_query_inspector.rs
@@ -1,3 +1,22 @@
+//! # filter_query_inspector act
+//!
+//! ## Usage
+//!
+//! ```no_run
+//! use bevy::prelude::*;
+//! use bevy_minibuffer::prelude::*;
+//! use bevy_inspector_egui::minibuffer;
+//! fn plugin(app: &mut App) {
+//!     app
+//!         .add_plugins(MinibufferPlugins)
+//!         .add_acts((
+//!             BasicActs::default(),
+//!             minibuffer::FilterQueryInspectorActs::default()
+//!                 .add::<With<Transform>>()
+//!                 .add::<With<Mesh3d>>()
+//!         ));
+//! }
+//! ```
 use crate::{
     minibuffer::{InspectorPlugins, Inspectors},
     quick::FilterQueryInspectorPlugin,
@@ -12,6 +31,8 @@ use bevy_ecs::{
 use bevy_minibuffer::{prelude::*, prompt::PromptState};
 use bevy_state::prelude::in_state;
 
+/// Adds the 'filter_query_inspector' act which toggles the visibility of the
+/// added filter query inspectors.
 pub struct FilterQueryInspectorActs {
     plugins: InspectorPlugins<Self>,
     acts: Acts,

--- a/crates/bevy-inspector-egui/src/minibuffer/inspector_plugins.rs
+++ b/crates/bevy-inspector-egui/src/minibuffer/inspector_plugins.rs
@@ -1,5 +1,6 @@
 use bevy_app::{App, Plugin, PluginGroup, PluginGroupBuilder};
 use bevy_ecs::prelude::{Res, ResMut, Resource, Trigger};
+use bevy_log::warn;
 use bevy_minibuffer::prelude::*;
 use std::borrow::Cow;
 use std::marker::PhantomData;
@@ -70,6 +71,13 @@ impl<M: Send + Sync + 'static> InspectorPlugins<M> {
             } else {
                 minibuffer.message(none_msg.clone());
             }
+        }
+    }
+
+    pub(crate) fn warn_on_empty(&self, msg: impl Into<Cow<'static, str>>) {
+        if self.names.is_empty() {
+            let msg = msg.into();
+            warn!("{}", msg);
         }
     }
 }

--- a/crates/bevy-inspector-egui/src/minibuffer/inspector_plugins.rs
+++ b/crates/bevy-inspector-egui/src/minibuffer/inspector_plugins.rs
@@ -1,18 +1,9 @@
 use bevy_app::{App, Plugin, PluginGroup, PluginGroupBuilder};
-use bevy_state::{state::FreelyMutableState, prelude::in_state};
-use bevy_minibuffer::{prelude::*, prompt::PromptState};
-use crate::{
-    quick::{WorldInspectorPlugin, StateInspectorPlugin},
-    utils::pretty_type_name,
-};
-use bevy_ecs::{prelude::{Resource, Res, ResMut, World, Trigger}, schedule::Condition};
-use bevy_state::app::AppExtStates;
-use bevy_state::prelude::{State, NextState, States};
-use bevy_egui::EguiContext;
-use bevy_reflect::Reflect;
-use trie_rs::map::Trie;
-use std::marker::PhantomData;
+use bevy_ecs::prelude::{Res, ResMut, Resource, Trigger};
+use bevy_minibuffer::prelude::*;
 use std::borrow::Cow;
+use std::marker::PhantomData;
+use trie_rs::map::Trie;
 
 #[derive(Resource)]
 pub(crate) struct Inspectors<M: Send + Sync + 'static> {
@@ -28,9 +19,11 @@ pub(crate) struct InspectorPlugins<M> {
 }
 
 impl<M: Send + Sync + 'static> InspectorPlugins<M> {
-    pub(crate) fn add_inspector<F: Fn(usize, &mut Self)>(&mut self,
-                                                         name: String,
-                                                         add_plugin_fn: F) {
+    pub(crate) fn add_inspector<F: Fn(usize, &mut Self)>(
+        &mut self,
+        name: String,
+        add_plugin_fn: F,
+    ) {
         let index = self.names.len();
         self.names.push(name);
         add_plugin_fn(index, self)
@@ -44,26 +37,36 @@ impl<M: Send + Sync + 'static> InspectorPlugins<M> {
     /// Return true if the inspector is marked as visible.
     pub(crate) fn visible(index: usize) -> impl Fn(Res<Inspectors<M>>) -> bool {
         move |inspectors: Res<Inspectors<M>>| {
-            inspectors.into_inner().visible.get(index).copied().unwrap_or(false)
+            inspectors
+                .into_inner()
+                .visible
+                .get(index)
+                .copied()
+                .unwrap_or(false)
         }
     }
 
-    pub(crate) fn inspector(prompt: impl Into<Cow<'static, str>>,
-                            none_msg: impl Into<Cow<'static, str>>) -> impl Fn(Res<Inspectors<M>>,
-                                                                               Minibuffer) {
+    // We could subsistute the inspector with this generic, but it felt a bit
+    // too rigid to go for this early.
+    #[allow(dead_code)]
+    pub(crate) fn inspector(
+        prompt: impl Into<Cow<'static, str>>,
+        none_msg: impl Into<Cow<'static, str>>,
+    ) -> impl Fn(Res<Inspectors<M>>, Minibuffer) {
         let prompt = prompt.into();
         let none_msg = none_msg.into();
-        move |inspectors: Res<Inspectors<M>>,
-        mut minibuffer: Minibuffer| {
+        move |inspectors: Res<Inspectors<M>>, mut minibuffer: Minibuffer| {
             if !inspectors.visible.is_empty() {
-                minibuffer.prompt_map(prompt.clone(), inspectors.names.clone())
-                          .observe(|mut trigger: Trigger<Completed<usize>>,
-                                   mut inspectors: ResMut<Inspectors<M>>,
-                                   mut minibuffer: Minibuffer| {
-                                       if let Ok(index) = trigger.event_mut().take_result().unwrap() {
-                                           inspectors.visible[index] = !inspectors.visible[index];
-                                       }
-                                   });
+                minibuffer
+                    .prompt_map(prompt.clone(), inspectors.names.clone())
+                    .observe(
+                        |mut trigger: Trigger<Completed<usize>>,
+                         mut inspectors: ResMut<Inspectors<M>>| {
+                            if let Ok(index) = trigger.event_mut().take_result().unwrap() {
+                                inspectors.visible[index] = !inspectors.visible[index];
+                            }
+                        },
+                    );
             } else {
                 minibuffer.message(none_msg.clone());
             }
@@ -76,7 +79,7 @@ impl<M: Send + Sync + 'static> Default for InspectorPlugins<M> {
         Self {
             plugins: Some(PluginGroupBuilder::start::<Self>()),
             names: vec![],
-            marker: PhantomData
+            marker: PhantomData,
         }
     }
 }
@@ -87,16 +90,21 @@ impl<M: Send + Sync + 'static> PluginGroup for InspectorPlugins<M> {
         // self.warn_on_unused_acts();
         builder.add(move |app: &mut App| {
             let count = self.names.len();
-            let trie = Trie::from_iter(self.names.clone().into_iter().enumerate().map(|(index, name)| (name, index)));
+            let trie = Trie::from_iter(
+                self.names
+                    .clone()
+                    .into_iter()
+                    .enumerate()
+                    .map(|(index, name)| (name, index)),
+            );
             app.insert_resource(Inspectors {
                 names: trie,
                 visible: vec![false; count],
-                marker: PhantomData::<M>
+                marker: PhantomData::<M>,
             });
         })
     }
 }
-
 
 // fn state_inspector_plugin<A: FreelyMutableState + Reflect>(index: usize) -> impl Fn(&mut App) {
 //     move |app: &mut App| {

--- a/crates/bevy-inspector-egui/src/minibuffer/inspector_plugins.rs
+++ b/crates/bevy-inspector-egui/src/minibuffer/inspector_plugins.rs
@@ -55,18 +55,18 @@ impl<M: Send + Sync + 'static> InspectorPlugins<M> {
         let none_msg = none_msg.into();
         move |inspectors: Res<Inspectors<M>>,
         mut minibuffer: Minibuffer| {
-        if !inspectors.visible.is_empty() {
-            minibuffer.prompt_map(prompt.clone(), inspectors.names.clone())
-                .observe(|mut trigger: Trigger<Completed<usize>>,
-                        mut inspectors: ResMut<Inspectors<M>>,
-                        mut minibuffer: Minibuffer| {
-                            if let Ok(index) = trigger.event_mut().take_result().unwrap() {
-                                inspectors.visible[index] = !inspectors.visible[index];
-                            }
-                });
-        } else {
-            minibuffer.message(none_msg.clone());
-        }
+            if !inspectors.visible.is_empty() {
+                minibuffer.prompt_map(prompt.clone(), inspectors.names.clone())
+                          .observe(|mut trigger: Trigger<Completed<usize>>,
+                                   mut inspectors: ResMut<Inspectors<M>>,
+                                   mut minibuffer: Minibuffer| {
+                                       if let Ok(index) = trigger.event_mut().take_result().unwrap() {
+                                           inspectors.visible[index] = !inspectors.visible[index];
+                                       }
+                                   });
+            } else {
+                minibuffer.message(none_msg.clone());
+            }
         }
     }
 }

--- a/crates/bevy-inspector-egui/src/minibuffer/inspector_plugins.rs
+++ b/crates/bevy-inspector-egui/src/minibuffer/inspector_plugins.rs
@@ -1,0 +1,107 @@
+use bevy_app::{App, Plugin, PluginGroup, PluginGroupBuilder};
+use bevy_state::{state::FreelyMutableState, prelude::in_state};
+use bevy_minibuffer::{prelude::*, prompt::PromptState};
+use crate::{
+    quick::{WorldInspectorPlugin, StateInspectorPlugin},
+    utils::pretty_type_name,
+};
+use bevy_ecs::{prelude::{Resource, Res, ResMut, World, Trigger}, schedule::Condition};
+use bevy_state::app::AppExtStates;
+use bevy_state::prelude::{State, NextState, States};
+use bevy_egui::EguiContext;
+use bevy_reflect::Reflect;
+use trie_rs::map::Trie;
+use std::marker::PhantomData;
+use std::borrow::Cow;
+
+#[derive(Resource)]
+pub(crate) struct Inspectors<M: Send + Sync + 'static> {
+    pub(crate) names: Trie<u8, usize>,
+    pub(crate) visible: Vec<bool>,
+    marker: PhantomData<M>,
+}
+
+pub(crate) struct InspectorPlugins<M> {
+    plugins: Option<PluginGroupBuilder>,
+    names: Vec<String>,
+    marker: PhantomData<M>,
+}
+
+impl<M: Send + Sync + 'static> InspectorPlugins<M> {
+    pub(crate) fn add_inspector<F: Fn(usize, &mut Self)>(&mut self,
+                                                         name: String,
+                                                         add_plugin_fn: F) {
+        let index = self.names.len();
+        self.names.push(name);
+        add_plugin_fn(index, self)
+    }
+
+    pub(crate) fn add_plugin<T: Plugin>(&mut self, plugin: T) {
+        let builder = self.plugins.take().expect("plugin builder");
+        self.plugins = Some(builder.add(plugin));
+    }
+
+    /// Return true if the inspector is marked as visible.
+    pub(crate) fn visible(index: usize) -> impl Fn(Res<Inspectors<M>>) -> bool {
+        move |inspectors: Res<Inspectors<M>>| {
+            inspectors.into_inner().visible.get(index).copied().unwrap_or(false)
+        }
+    }
+
+    pub(crate) fn inspector(prompt: impl Into<Cow<'static, str>>,
+                            none_msg: impl Into<Cow<'static, str>>) -> impl Fn(Res<Inspectors<M>>,
+                                                                               Minibuffer) {
+        let prompt = prompt.into();
+        let none_msg = none_msg.into();
+        move |inspectors: Res<Inspectors<M>>,
+        mut minibuffer: Minibuffer| {
+        if !inspectors.visible.is_empty() {
+            minibuffer.prompt_map(prompt.clone(), inspectors.names.clone())
+                .observe(|mut trigger: Trigger<Completed<usize>>,
+                        mut inspectors: ResMut<Inspectors<M>>,
+                        mut minibuffer: Minibuffer| {
+                            if let Ok(index) = trigger.event_mut().take_result().unwrap() {
+                                inspectors.visible[index] = !inspectors.visible[index];
+                            }
+                });
+        } else {
+            minibuffer.message(none_msg.clone());
+        }
+        }
+    }
+}
+
+impl<M: Send + Sync + 'static> Default for InspectorPlugins<M> {
+    fn default() -> Self {
+        Self {
+            plugins: Some(PluginGroupBuilder::start::<Self>()),
+            names: vec![],
+            marker: PhantomData
+        }
+    }
+}
+
+impl<M: Send + Sync + 'static> PluginGroup for InspectorPlugins<M> {
+    fn build(mut self) -> PluginGroupBuilder {
+        let builder = self.plugins.take().expect("plugin builder");
+        // self.warn_on_unused_acts();
+        builder.add(move |app: &mut App| {
+            let count = self.names.len();
+            let trie = Trie::from_iter(self.names.clone().into_iter().enumerate().map(|(index, name)| (name, index)));
+            app.insert_resource(Inspectors {
+                names: trie,
+                visible: vec![false; count],
+                marker: PhantomData::<M>
+            });
+        })
+    }
+}
+
+
+// fn state_inspector_plugin<A: FreelyMutableState + Reflect>(index: usize) -> impl Fn(&mut App) {
+//     move |app: &mut App| {
+//         app.add_plugins(StateInspectorPlugin::<A>::default()
+//                         .run_if(in_state(PromptState::Visible).and(state_visible(index)))
+//         );
+//     }
+// }

--- a/crates/bevy-inspector-egui/src/minibuffer/mod.rs
+++ b/crates/bevy-inspector-egui/src/minibuffer/mod.rs
@@ -46,10 +46,9 @@
 //!
 //! ### Type Registration
 //!
-//! Each of the other acts do require configuration in the form of type
-//! registration. For instance, the `AssetInspectorActs` provides
-//! 'asset_inspector' but requires registration of what assets it should prompt
-//! for when the act is invoked.
+//! Each of the other acts do require type registration. For instance, the
+//! `AssetInspectorActs` provides 'asset_inspector' but requires registration of
+//! what assets it should prompt for when the act is invoked.
 //!
 //! ```no_run
 //! use bevy::prelude::*;

--- a/crates/bevy-inspector-egui/src/minibuffer/mod.rs
+++ b/crates/bevy-inspector-egui/src/minibuffer/mod.rs
@@ -1,19 +1,17 @@
-use bevy_app::{App, Plugin, PluginGroup, PluginGroupBuilder};
-use bevy_state::prelude::in_state;
-use bevy_minibuffer::{prelude::*, prompt::PromptState};
-use crate::{
-    quick::{WorldInspectorPlugin, ResourceInspectorPlugin},
-    utils::pretty_type_name,
+use crate::quick::WorldInspectorPlugin;
+use bevy_app::{App, Plugin};
+use bevy_ecs::{
+    prelude::{Res, ResMut},
+    schedule::Condition,
 };
-use bevy_ecs::{prelude::{Res, ResMut, Resource, World, Trigger}, schedule::Condition};
-use bevy_state::app::AppExtStates;
-use bevy_state::prelude::{State, NextState, States};
-use bevy_egui::EguiContext;
+use bevy_minibuffer::{prelude::*, prompt::PromptState};
 use bevy_reflect::Reflect;
-use trie_rs::map::Trie;
+use bevy_state::app::AppExtStates;
+use bevy_state::prelude::in_state;
+use bevy_state::prelude::{NextState, State, States};
 
 mod inspector_plugins;
-pub use inspector_plugins::*;
+pub(crate) use inspector_plugins::*;
 mod resource_inspector;
 pub use resource_inspector::*;
 mod asset_inspector;
@@ -33,74 +31,11 @@ pub enum WorldInspectorState {
     Visible,
 }
 
-#[derive(Resource)]
-pub struct ResourceInspectors {
-    names: Trie<u8, usize>,
-    visible: Vec<bool>,
-}
-
-pub struct ResourceInspectorPlugins {
-    plugins: Option<PluginGroupBuilder>,
-    resource_names: Vec<String>,
-}
-
-impl ResourceInspectorPlugins {
-    pub fn add<R: Resource + Reflect>(mut self) -> Self {
-        let index = self.resource_names.len();
-        self.resource_names.push(pretty_type_name::<R>());
-        self.add_plugin(resource_inspector_plugin::<R>(index));
-        self
-    }
-
-    fn add_plugin<T: Plugin>(&mut self, plugin: T) {
-        let builder = self.plugins.take().expect("plugin builder");
-        self.plugins = Some(builder.add(plugin));
-    }
-}
-
-impl Default for ResourceInspectorPlugins {
-    fn default() -> Self {
-        Self {
-            plugins: Some(PluginGroupBuilder::start::<Self>()),
-            resource_names: vec![],
-        }
-    }
-}
-
-impl PluginGroup for ResourceInspectorPlugins {
-    fn build(mut self) -> PluginGroupBuilder {
-        let builder = self.plugins.take().expect("plugin builder");
-        // let resource_names = self.resource_names.drain(..);
-        builder.add(move |app: &mut App| {
-            let count = self.resource_names.len();
-            let trie = Trie::from_iter(self.resource_names.clone().into_iter().enumerate().map(|(index, name)| (name, index)));
-            app.insert_resource(ResourceInspectors {
-                names: trie,
-                visible: vec![false; count],
-            });
-        })
-    }
-}
-
-pub struct InspectorActs {
+pub struct WorldInspectorActs {
     pub acts: Acts,
 }
 
-fn resource_visible(index: usize) -> impl Fn(Res<ResourceInspectors>) -> bool {
-    move |inspectors: Res<ResourceInspectors>| {
-        inspectors.visible.get(index).copied().unwrap_or(false)
-    }
-}
-
-fn resource_inspector_plugin<R: Resource + Reflect>(index: usize) -> impl Fn(&mut App) {
-    move |app: &mut App| {
-        app.add_plugins(ResourceInspectorPlugin::<R>::default()
-                    .run_if(in_state(PromptState::Visible).and(resource_visible(index)))
-        );
-    }
-}
-
-impl ActsPlugin for InspectorActs {
+impl ActsPlugin for WorldInspectorActs {
     fn acts(&self) -> &Acts {
         &self.acts
     }
@@ -109,9 +44,11 @@ impl ActsPlugin for InspectorActs {
     }
 }
 
-fn world_inspector(state: Res<State<WorldInspectorState>>,
-                   mut next_state: ResMut<NextState<WorldInspectorState>>,
-                   mut minibuffer: Minibuffer) {
+fn world_inspector(
+    state: Res<State<WorldInspectorState>>,
+    mut next_state: ResMut<NextState<WorldInspectorState>>,
+    mut minibuffer: Minibuffer,
+) {
     use WorldInspectorState::*;
     let (state, msg) = match state.get() {
         Invisible => (Visible, "Show world inspector"),
@@ -121,20 +58,21 @@ fn world_inspector(state: Res<State<WorldInspectorState>>,
     minibuffer.message(msg);
 }
 
-impl Default for InspectorActs {
+impl Default for WorldInspectorActs {
     fn default() -> Self {
         Self {
-            acts: Acts::new([
-                Act::new(world_inspector),
-                ]),
+            acts: Acts::new([Act::new(world_inspector)]),
         }
     }
 }
 
-impl Plugin for InspectorActs {
+impl Plugin for WorldInspectorActs {
     fn build(&self, app: &mut App) {
-        app.add_plugins(WorldInspectorPlugin::default().run_if(in_state(PromptState::Visible).and(in_state(WorldInspectorState::Visible))))
-            .init_state::<WorldInspectorState>();
+        app.add_plugins(
+            WorldInspectorPlugin::default()
+                .run_if(in_state(PromptState::Visible).and(in_state(WorldInspectorState::Visible))),
+        )
+        .init_state::<WorldInspectorState>();
         self.warn_on_unused_acts();
     }
 }

--- a/crates/bevy-inspector-egui/src/minibuffer/mod.rs
+++ b/crates/bevy-inspector-egui/src/minibuffer/mod.rs
@@ -18,6 +18,8 @@ mod asset_inspector;
 pub use asset_inspector::*;
 mod state_inspector;
 pub use state_inspector::*;
+mod inspector_plugins;
+pub use inspector_plugins::*;
 
 /// Is the prompt visible?
 #[derive(Debug, Clone, Copy, Default, Eq, PartialEq, Hash, States, Reflect)]

--- a/crates/bevy-inspector-egui/src/minibuffer/mod.rs
+++ b/crates/bevy-inspector-egui/src/minibuffer/mod.rs
@@ -1,17 +1,88 @@
-use crate::quick::WorldInspectorPlugin;
-use bevy_app::{App, Plugin};
-use bevy_ecs::{
-    prelude::{Res, ResMut},
-    schedule::Condition,
-};
-use bevy_minibuffer::{prelude::*, prompt::PromptState};
-use bevy_reflect::Reflect;
-use bevy_state::app::AppExtStates;
-use bevy_state::prelude::in_state;
-use bevy_state::prelude::{NextState, State, States};
+//! # bevy_minibuffer integration
+//!
+//! This module integrates with
+//! [bevy_minibuffer](https://github.com/shanecelis/bevy_minibuffer) to provide
+//! another means of invoking inspectors.
+//!
+//! ## Acts
+//!
+//! The minibuffer acts, i.e., commands this module makes available are:
+//! - world_inspector
+//! - resource_inspector
+//! - asset_inspector
+//! - state_inspector
+//! - filter_query_inspector
+//!
+//! They may be used _a la carte_.
+//!
+//! ## Interaction
+//!
+//! Here is what interaction for 'world_insepctor' might look like:
+//!
+//! User types ':' or 'Alt-X', a black bar and prompt appear at the bottom of
+//! the screen---that's the minibuffer. The user types 'world Tab Return' to tab
+//! complete the 'world_inspector' act. The world inspector appears. If the user
+//! hits the 'BackTick' (`) key, the minibuffer will disappear and so will the
+//! inspector. Hit the 'BackTick' key again, and both reappear.
+//!
+//! ## Configuration
+//!
+//! The `WorldInspectorActs` provides 'world_inspector' act and it is the only
+//! one that does not require any type registration.
+//!
+//! ```no_run
+//! use bevy::prelude::*;
+//! use bevy_minibuffer::prelude::*;
+//! use bevy_inspector_egui::minibuffer;
+//! fn plugin(app: &mut App) {
+//!     app
+//!         .add_plugins(MinibufferPlugins)
+//!         .add_acts((
+//!             BasicActs::default(),
+//!             minibuffer::WorldInspectorActs::default(),
+//!         ));
+//! }
+//! ```
+//!
+//! ### Type Registration
+//!
+//! Each of the other acts do require configuration in the form of type
+//! registration. For instance, the `AssetInspectorActs` provides
+//! 'asset_inspector' but requires registration of what assets it should prompt
+//! for when the act is invoked.
+//!
+//! ```no_run
+//! use bevy::prelude::*;
+//! use bevy_minibuffer::prelude::*;
+//! use bevy_inspector_egui::minibuffer;
+//! fn plugin(app: &mut App) {
+//!     app
+//!         .add_plugins(MinibufferPlugins)
+//!         .add_acts((
+//!             BasicActs::default(),
+//!             minibuffer::AssetInspectorActs::default()
+//!                 .add::<StandardMaterial>()
+//!         ));
+//! }
+//! ```
+//!
+//! There may be ways to automatically register various assets, resources, but I
+//! would actually decline to do that. It can quickly make a mess, become
+//! overwhelming, and takes control out of the user's hands.
+//!
+//! ## Visibility
+//!
+//! Each act toggles the visibility of an inspector. However, each inspector's
+//! visibility is tied to minibuffer's visibility. When minibuffer is invisible
+//! so are its inspectors and vice versa.
+//!
+//! NOTE: Any inspectors configured without this module are independent of
+//! minibuffer's influence, so that's one escape hatch to this behavior.
 
 mod inspector_plugins;
 pub(crate) use inspector_plugins::*;
+mod world_inspector;
+pub use world_inspector::*;
 mod resource_inspector;
 pub use resource_inspector::*;
 mod asset_inspector;
@@ -20,59 +91,3 @@ mod state_inspector;
 pub use state_inspector::*;
 mod filter_query_inspector;
 pub use filter_query_inspector::*;
-
-/// Is the prompt visible?
-#[derive(Debug, Clone, Copy, Default, Eq, PartialEq, Hash, States, Reflect)]
-pub enum WorldInspectorState {
-    /// Invisible
-    #[default]
-    Invisible,
-    /// Visible
-    Visible,
-}
-
-pub struct WorldInspectorActs {
-    pub acts: Acts,
-}
-
-impl ActsPlugin for WorldInspectorActs {
-    fn acts(&self) -> &Acts {
-        &self.acts
-    }
-    fn acts_mut(&mut self) -> &mut Acts {
-        &mut self.acts
-    }
-}
-
-fn world_inspector(
-    state: Res<State<WorldInspectorState>>,
-    mut next_state: ResMut<NextState<WorldInspectorState>>,
-    mut minibuffer: Minibuffer,
-) {
-    use WorldInspectorState::*;
-    let (state, msg) = match state.get() {
-        Invisible => (Visible, "Show world inspector"),
-        Visible => (Invisible, "Hide world inspector"),
-    };
-    next_state.set(state);
-    minibuffer.message(msg);
-}
-
-impl Default for WorldInspectorActs {
-    fn default() -> Self {
-        Self {
-            acts: Acts::new([Act::new(world_inspector)]),
-        }
-    }
-}
-
-impl Plugin for WorldInspectorActs {
-    fn build(&self, app: &mut App) {
-        app.add_plugins(
-            WorldInspectorPlugin::default()
-                .run_if(in_state(PromptState::Visible).and(in_state(WorldInspectorState::Visible))),
-        )
-        .init_state::<WorldInspectorState>();
-        self.warn_on_unused_acts();
-    }
-}

--- a/crates/bevy-inspector-egui/src/minibuffer/mod.rs
+++ b/crates/bevy-inspector-egui/src/minibuffer/mod.rs
@@ -12,14 +12,16 @@ use bevy_egui::EguiContext;
 use bevy_reflect::Reflect;
 use trie_rs::map::Trie;
 
+mod inspector_plugins;
+pub use inspector_plugins::*;
 mod resource_inspector;
 pub use resource_inspector::*;
 mod asset_inspector;
 pub use asset_inspector::*;
 mod state_inspector;
 pub use state_inspector::*;
-mod inspector_plugins;
-pub use inspector_plugins::*;
+mod filter_query_inspector;
+pub use filter_query_inspector::*;
 
 /// Is the prompt visible?
 #[derive(Debug, Clone, Copy, Default, Eq, PartialEq, Hash, States, Reflect)]

--- a/crates/bevy-inspector-egui/src/minibuffer/mod.rs
+++ b/crates/bevy-inspector-egui/src/minibuffer/mod.rs
@@ -15,6 +15,26 @@
 //!
 //! They may be used _a la carte_.
 //!
+//! ## Key Bindings
+//!
+//! No key bindings have been defined. Users are welcome to add them.
+//!
+//! ```no_run
+//! use bevy_minibuffer::prelude::*;
+//! use bevy_inspector_egui::minibuffer;
+//! let mut inspector_acts = minibuffer::WorldInspectorActs::default();
+//! inspector_acts.acts_mut().configure("world_inspector", |mut act| {
+//!    act.bind(keyseq! { I W });
+//! });
+//! ```
+//!
+//! But I do wonder if maybe some bindings like this would work:
+//! - world_inspector, I W
+//! - resource_inspector, I R
+//! - asset_inspector, I A
+//! - state_inspector, I S
+//! - filter_query_inspector, I F
+//!
 //! ## Interaction
 //!
 //! Here is what interaction for 'world_insepctor' might look like:
@@ -46,9 +66,10 @@
 //!
 //! ### Type Registration
 //!
-//! Each of the other acts do require type registration. For instance, the
-//! `AssetInspectorActs` provides 'asset_inspector' but requires registration of
-//! what assets it should prompt for when the act is invoked.
+//! Each of the other acts do expect type registrations. For instance, the
+//! `AssetInspectorActs` provides 'asset_inspector' but expects registration of
+//! what assets it should prompt for when the act is invoked. A warning will be
+//! emitted if no types have been registered.
 //!
 //! ```no_run
 //! use bevy::prelude::*;
@@ -65,9 +86,10 @@
 //! }
 //! ```
 //!
-//! There may be ways to automatically register various assets, resources, but I
-//! would actually decline to do that. It can quickly make a mess, become
-//! overwhelming, and takes control out of the user's hands.
+//! DESIGN NOTE: There may be ways to automatically register various assets,
+//! resources, and other types but I would actually decline to do that. It can
+//! quickly make a mess, become overwhelming, and takes control out of the
+//! user's hands.
 //!
 //! ## Visibility
 //!
@@ -75,8 +97,9 @@
 //! visibility is tied to minibuffer's visibility. When minibuffer is invisible
 //! so are its inspectors and vice versa.
 //!
-//! NOTE: Any inspectors configured without this module are independent of
-//! minibuffer's influence, so that's one escape hatch to this behavior.
+//! NOTE: Any inspectors configured without the minibuffer module are
+//! independent of minibuffer's influence, so that's one escape hatch to this
+//! behavior.
 
 mod inspector_plugins;
 pub(crate) use inspector_plugins::*;

--- a/crates/bevy-inspector-egui/src/minibuffer/resource_inspector.rs
+++ b/crates/bevy-inspector-egui/src/minibuffer/resource_inspector.rs
@@ -1,26 +1,3 @@
-//! # resource_inspector act
-//!
-//! ## Usage
-//!
-//! ```no_run
-//! use bevy::prelude::*;
-//! use bevy_minibuffer::prelude::*;
-//! use bevy_inspector_egui::minibuffer;
-//! #[derive(Resource, Reflect)]
-//! struct R1;
-//! #[derive(Resource, Reflect)]
-//! struct R2;
-//! fn plugin(app: &mut App) {
-//!     app
-//!         .add_plugins(MinibufferPlugins)
-//!         .add_acts((
-//!             BasicActs::default(),
-//!             minibuffer::ResourceInspectorActs::default()
-//!                 .add::<R1>()
-//!                 .add::<R2>()
-//!         ));
-//! }
-//! ```
 use crate::{
     minibuffer::{InspectorPlugins, Inspectors},
     quick::ResourceInspectorPlugin,
@@ -35,8 +12,31 @@ use bevy_minibuffer::{prelude::*, prompt::PromptState};
 use bevy_reflect::Reflect;
 use bevy_state::prelude::in_state;
 
-/// Adds the 'resource_inspector' act which toggles the visibility of resource
-/// inspectors that were added.
+/// ## Adds the 'resource_inspector' act
+///
+/// This act toggles the visibility of resource inspectors that were added.
+///
+/// ## Usage
+///
+/// ```no_run
+/// use bevy::prelude::*;
+/// use bevy_minibuffer::prelude::*;
+/// use bevy_inspector_egui::minibuffer;
+/// #[derive(Resource, Reflect)]
+/// struct R1;
+/// #[derive(Resource, Reflect)]
+/// struct R2;
+/// fn plugin(app: &mut App) {
+///     app
+///         .add_plugins(MinibufferPlugins)
+///         .add_acts((
+///             BasicActs::default(),
+///             minibuffer::ResourceInspectorActs::default()
+///                 .add::<R1>()
+///                 .add::<R2>()
+///         ));
+/// }
+/// ```
 pub struct ResourceInspectorActs {
     plugins: InspectorPlugins<Self>,
     acts: Acts,
@@ -106,6 +106,7 @@ fn resource_inspector(
 impl PluginGroup for ResourceInspectorActs {
     fn build(self) -> PluginGroupBuilder {
         self.warn_on_unused_acts();
+        self.plugins.warn_on_empty("No resources registered with `ResourceInspectorActs`; consider adding some.");
         self.plugins.build()
     }
 }

--- a/crates/bevy-inspector-egui/src/minibuffer/resource_inspector.rs
+++ b/crates/bevy-inspector-egui/src/minibuffer/resource_inspector.rs
@@ -1,17 +1,16 @@
-use bevy_app::{App, Plugin, PluginGroup, PluginGroupBuilder};
-use bevy_state::prelude::in_state;
-use bevy_minibuffer::{prelude::*, prompt::PromptState};
 use crate::{
-    quick::{WorldInspectorPlugin, ResourceInspectorPlugin},
-    utils::pretty_type_name,
     minibuffer::{InspectorPlugins, Inspectors},
+    quick::ResourceInspectorPlugin,
+    utils::pretty_type_name,
 };
-use bevy_ecs::{prelude::{Res, ResMut, Resource, World, Trigger}, schedule::Condition};
-use bevy_state::app::AppExtStates;
-use bevy_state::prelude::{State, NextState, States};
-use bevy_egui::EguiContext;
+use bevy_app::{PluginGroup, PluginGroupBuilder};
+use bevy_ecs::{
+    prelude::{Res, ResMut, Resource, Trigger},
+    schedule::Condition,
+};
+use bevy_minibuffer::{prelude::*, prompt::PromptState};
 use bevy_reflect::Reflect;
-use trie_rs::map::Trie;
+use bevy_state::prelude::in_state;
 
 pub struct ResourceInspectorActs {
     plugins: InspectorPlugins<Self>,
@@ -30,13 +29,22 @@ impl ActsPluginGroup for ResourceInspectorActs {
 
 impl ResourceInspectorActs {
     pub fn add<R: Resource + Reflect>(mut self) -> Self {
-        self.plugins.add_inspector(pretty_type_name::<R>(), Self::resource_inspector_plugin::<R>);
+        self.plugins.add_inspector(
+            pretty_type_name::<R>(),
+            Self::resource_inspector_plugin::<R>,
+        );
         self
     }
 
-    fn resource_inspector_plugin<R: Resource + Reflect>(index: usize, inspector_plugins: &mut InspectorPlugins<Self>) {
-        inspector_plugins.add_plugin(ResourceInspectorPlugin::<R>::default()
-                                     .run_if(in_state(PromptState::Visible).and(InspectorPlugins::<Self>::visible(index))));
+    fn resource_inspector_plugin<R: Resource + Reflect>(
+        index: usize,
+        inspector_plugins: &mut InspectorPlugins<Self>,
+    ) {
+        inspector_plugins.add_plugin(
+            ResourceInspectorPlugin::<R>::default().run_if(
+                in_state(PromptState::Visible).and(InspectorPlugins::<Self>::visible(index)),
+            ),
+        );
     }
 }
 
@@ -49,26 +57,28 @@ impl Default for ResourceInspectorActs {
     }
 }
 
-fn resource_inspector(resources: Res<Inspectors<ResourceInspectorActs>>,
-                      mut minibuffer: Minibuffer) {
-
+fn resource_inspector(
+    resources: Res<Inspectors<ResourceInspectorActs>>,
+    mut minibuffer: Minibuffer,
+) {
     if !resources.visible.is_empty() {
-        minibuffer.prompt_map("resource: ", resources.names.clone())
-            .observe(|mut trigger: Trigger<Completed<usize>>,
-                     mut resources: ResMut<Inspectors<ResourceInspectorActs>>,
-                     mut minibuffer: Minibuffer| {
-                         if let Ok(index) = trigger.event_mut().take_result().unwrap() {
-                             resources.visible[index] = !resources.visible[index];
-                         }
-            });
+        minibuffer
+            .prompt_map("resource: ", resources.names.clone())
+            .observe(
+                |mut trigger: Trigger<Completed<usize>>,
+                 mut resources: ResMut<Inspectors<ResourceInspectorActs>>| {
+                    if let Ok(index) = trigger.event_mut().take_result().unwrap() {
+                        resources.visible[index] = !resources.visible[index];
+                    }
+                },
+            );
     } else {
         minibuffer.message("No resource inspectors available.");
     }
 }
 
-
 impl PluginGroup for ResourceInspectorActs {
-    fn build(mut self) -> PluginGroupBuilder {
+    fn build(self) -> PluginGroupBuilder {
         self.warn_on_unused_acts();
         self.plugins.build()
     }

--- a/crates/bevy-inspector-egui/src/minibuffer/resource_inspector.rs
+++ b/crates/bevy-inspector-egui/src/minibuffer/resource_inspector.rs
@@ -106,7 +106,9 @@ fn resource_inspector(
 impl PluginGroup for ResourceInspectorActs {
     fn build(self) -> PluginGroupBuilder {
         self.warn_on_unused_acts();
-        self.plugins.warn_on_empty("No resources registered with `ResourceInspectorActs`; consider adding some.");
+        self.plugins.warn_on_empty(
+            "No resources registered with `ResourceInspectorActs`; consider adding some.",
+        );
         self.plugins.build()
     }
 }

--- a/crates/bevy-inspector-egui/src/minibuffer/resource_inspector.rs
+++ b/crates/bevy-inspector-egui/src/minibuffer/resource_inspector.rs
@@ -1,3 +1,26 @@
+//! # resource_inspector act
+//!
+//! ## Usage
+//!
+//! ```no_run
+//! use bevy::prelude::*;
+//! use bevy_minibuffer::prelude::*;
+//! use bevy_inspector_egui::minibuffer;
+//! #[derive(Resource, Reflect)]
+//! struct R1;
+//! #[derive(Resource, Reflect)]
+//! struct R2;
+//! fn plugin(app: &mut App) {
+//!     app
+//!         .add_plugins(MinibufferPlugins)
+//!         .add_acts((
+//!             BasicActs::default(),
+//!             minibuffer::ResourceInspectorActs::default()
+//!                 .add::<R1>()
+//!                 .add::<R2>()
+//!         ));
+//! }
+//! ```
 use crate::{
     minibuffer::{InspectorPlugins, Inspectors},
     quick::ResourceInspectorPlugin,
@@ -12,6 +35,8 @@ use bevy_minibuffer::{prelude::*, prompt::PromptState};
 use bevy_reflect::Reflect;
 use bevy_state::prelude::in_state;
 
+/// Adds the 'resource_inspector' act which toggles the visibility of resource
+/// inspectors that were added.
 pub struct ResourceInspectorActs {
     plugins: InspectorPlugins<Self>,
     acts: Acts,
@@ -28,6 +53,7 @@ impl ActsPluginGroup for ResourceInspectorActs {
 }
 
 impl ResourceInspectorActs {
+    /// Add a resource to the list of resources when prompted.
     pub fn add<R: Resource + Reflect>(mut self) -> Self {
         self.plugins.add_inspector(
             pretty_type_name::<R>(),

--- a/crates/bevy-inspector-egui/src/minibuffer/resource_inspector.rs
+++ b/crates/bevy-inspector-egui/src/minibuffer/resource_inspector.rs
@@ -1,0 +1,111 @@
+use bevy_app::{App, Plugin, PluginGroup, PluginGroupBuilder};
+use bevy_state::prelude::in_state;
+use bevy_minibuffer::{prelude::*, prompt::PromptState};
+use crate::{
+    quick::{WorldInspectorPlugin, ResourceInspectorPlugin},
+    utils::pretty_type_name,
+};
+use bevy_ecs::{prelude::{Res, ResMut, Resource, World, Trigger}, schedule::Condition};
+use bevy_state::app::AppExtStates;
+use bevy_state::prelude::{State, NextState, States};
+use bevy_egui::EguiContext;
+use bevy_reflect::Reflect;
+use trie_rs::map::Trie;
+
+#[derive(Resource)]
+pub struct ResourceInspectors {
+    names: Trie<u8, usize>,
+    visible: Vec<bool>,
+}
+
+pub struct ResourceInspectorActs {
+    plugins: Option<PluginGroupBuilder>,
+    acts: Acts,
+    resource_names: Vec<String>,
+}
+
+impl ActsPluginGroup for ResourceInspectorActs {
+    fn acts(&self) -> &Acts {
+        &self.acts
+    }
+
+    fn acts_mut(&mut self) -> &mut Acts {
+        &mut self.acts
+    }
+}
+
+// impl PluginGroup for ResourceInspectorActs {
+//     fn
+
+// }
+
+impl ResourceInspectorActs {
+    pub fn add<R: Resource + Reflect>(mut self) -> Self {
+        let index = self.resource_names.len();
+        self.resource_names.push(pretty_type_name::<R>());
+        self.add_plugin(resource_inspector_plugin::<R>(index));
+        self
+    }
+
+    fn add_plugin<T: Plugin>(&mut self, plugin: T) {
+        let builder = self.plugins.take().expect("plugin builder");
+        self.plugins = Some(builder.add(plugin));
+    }
+}
+
+impl Default for ResourceInspectorActs {
+    fn default() -> Self {
+        Self {
+            plugins: Some(PluginGroupBuilder::start::<Self>()),
+            acts: Acts::new([Act::new(resource_inspector)]),
+            resource_names: vec![],
+        }
+    }
+}
+
+fn resource_inspector(resources: Option<Res<ResourceInspectors>>,
+                      mut minibuffer: Minibuffer) {
+    if let Some(ref resources) = resources {
+        minibuffer.prompt_map("resource: ", resources.names.clone())
+            .observe(|mut trigger: Trigger<Completed<usize>>,
+                     mut resources: ResMut<ResourceInspectors>,
+                     mut minibuffer: Minibuffer| {
+                         if let Ok(index) = trigger.event_mut().take_result().unwrap() {
+                             resources.visible[index] = !resources.visible[index];
+                         }
+            });
+    } else {
+        minibuffer.message("No resource inspectors available.");
+    }
+}
+
+
+impl PluginGroup for ResourceInspectorActs {
+    fn build(mut self) -> PluginGroupBuilder {
+        let builder = self.plugins.take().expect("plugin builder");
+        // let resource_names = self.resource_names.drain(..);
+        self.warn_on_unused_acts();
+        builder.add(move |app: &mut App| {
+            let count = self.resource_names.len();
+            let trie = Trie::from_iter(self.resource_names.clone().into_iter().enumerate().map(|(index, name)| (name, index)));
+            app.insert_resource(ResourceInspectors {
+                names: trie,
+                visible: vec![false; count],
+            });
+        })
+    }
+}
+
+fn resource_visible(index: usize) -> impl Fn(Res<ResourceInspectors>) -> bool {
+    move |inspectors: Res<ResourceInspectors>| {
+        inspectors.visible.get(index).copied().unwrap_or(false)
+    }
+}
+
+fn resource_inspector_plugin<R: Resource + Reflect>(index: usize) -> impl Fn(&mut App) {
+    move |app: &mut App| {
+        app.add_plugins(ResourceInspectorPlugin::<R>::default()
+                    .run_if(in_state(PromptState::Visible).and(resource_visible(index)))
+        );
+    }
+}

--- a/crates/bevy-inspector-egui/src/minibuffer/resource_inspector.rs
+++ b/crates/bevy-inspector-egui/src/minibuffer/resource_inspector.rs
@@ -4,6 +4,7 @@ use bevy_minibuffer::{prelude::*, prompt::PromptState};
 use crate::{
     quick::{WorldInspectorPlugin, ResourceInspectorPlugin},
     utils::pretty_type_name,
+    minibuffer::{InspectorPlugins, Inspectors},
 };
 use bevy_ecs::{prelude::{Res, ResMut, Resource, World, Trigger}, schedule::Condition};
 use bevy_state::app::AppExtStates;
@@ -12,16 +13,9 @@ use bevy_egui::EguiContext;
 use bevy_reflect::Reflect;
 use trie_rs::map::Trie;
 
-#[derive(Resource)]
-pub struct ResourceInspectors {
-    names: Trie<u8, usize>,
-    visible: Vec<bool>,
-}
-
 pub struct ResourceInspectorActs {
-    plugins: Option<PluginGroupBuilder>,
+    plugins: InspectorPlugins<Self>,
     acts: Acts,
-    resource_names: Vec<String>,
 }
 
 impl ActsPluginGroup for ResourceInspectorActs {
@@ -34,41 +28,34 @@ impl ActsPluginGroup for ResourceInspectorActs {
     }
 }
 
-// impl PluginGroup for ResourceInspectorActs {
-//     fn
-
-// }
-
 impl ResourceInspectorActs {
     pub fn add<R: Resource + Reflect>(mut self) -> Self {
-        let index = self.resource_names.len();
-        self.resource_names.push(pretty_type_name::<R>());
-        self.add_plugin(resource_inspector_plugin::<R>(index));
+        self.plugins.add_inspector(pretty_type_name::<R>(), Self::resource_inspector_plugin::<R>);
         self
     }
 
-    fn add_plugin<T: Plugin>(&mut self, plugin: T) {
-        let builder = self.plugins.take().expect("plugin builder");
-        self.plugins = Some(builder.add(plugin));
+    fn resource_inspector_plugin<R: Resource + Reflect>(index: usize, inspector_plugins: &mut InspectorPlugins<Self>) {
+        inspector_plugins.add_plugin(ResourceInspectorPlugin::<R>::default()
+                                     .run_if(in_state(PromptState::Visible).and(InspectorPlugins::<Self>::visible(index))));
     }
 }
 
 impl Default for ResourceInspectorActs {
     fn default() -> Self {
         Self {
-            plugins: Some(PluginGroupBuilder::start::<Self>()),
+            plugins: InspectorPlugins::default(),
             acts: Acts::new([Act::new(resource_inspector)]),
-            resource_names: vec![],
         }
     }
 }
 
-fn resource_inspector(resources: Option<Res<ResourceInspectors>>,
+fn resource_inspector(resources: Res<Inspectors<ResourceInspectorActs>>,
                       mut minibuffer: Minibuffer) {
-    if let Some(ref resources) = resources {
+
+    if !resources.visible.is_empty() {
         minibuffer.prompt_map("resource: ", resources.names.clone())
             .observe(|mut trigger: Trigger<Completed<usize>>,
-                     mut resources: ResMut<ResourceInspectors>,
+                     mut resources: ResMut<Inspectors<ResourceInspectorActs>>,
                      mut minibuffer: Minibuffer| {
                          if let Ok(index) = trigger.event_mut().take_result().unwrap() {
                              resources.visible[index] = !resources.visible[index];
@@ -82,30 +69,7 @@ fn resource_inspector(resources: Option<Res<ResourceInspectors>>,
 
 impl PluginGroup for ResourceInspectorActs {
     fn build(mut self) -> PluginGroupBuilder {
-        let builder = self.plugins.take().expect("plugin builder");
-        // let resource_names = self.resource_names.drain(..);
         self.warn_on_unused_acts();
-        builder.add(move |app: &mut App| {
-            let count = self.resource_names.len();
-            let trie = Trie::from_iter(self.resource_names.clone().into_iter().enumerate().map(|(index, name)| (name, index)));
-            app.insert_resource(ResourceInspectors {
-                names: trie,
-                visible: vec![false; count],
-            });
-        })
-    }
-}
-
-fn resource_visible(index: usize) -> impl Fn(Res<ResourceInspectors>) -> bool {
-    move |inspectors: Res<ResourceInspectors>| {
-        inspectors.visible.get(index).copied().unwrap_or(false)
-    }
-}
-
-fn resource_inspector_plugin<R: Resource + Reflect>(index: usize) -> impl Fn(&mut App) {
-    move |app: &mut App| {
-        app.add_plugins(ResourceInspectorPlugin::<R>::default()
-                    .run_if(in_state(PromptState::Visible).and(resource_visible(index)))
-        );
+        self.plugins.build()
     }
 }

--- a/crates/bevy-inspector-egui/src/minibuffer/state_inspector.rs
+++ b/crates/bevy-inspector-egui/src/minibuffer/state_inspector.rs
@@ -1,0 +1,104 @@
+use bevy_app::{App, Plugin, PluginGroup, PluginGroupBuilder};
+use bevy_state::{state::FreelyMutableState, prelude::in_state};
+use bevy_minibuffer::{prelude::*, prompt::PromptState};
+use crate::{
+    quick::{WorldInspectorPlugin, StateInspectorPlugin},
+    utils::pretty_type_name,
+};
+use bevy_ecs::{prelude::{Resource, Res, ResMut, World, Trigger}, schedule::Condition};
+use bevy_state::app::AppExtStates;
+use bevy_state::prelude::{State, NextState, States};
+use bevy_egui::EguiContext;
+use bevy_reflect::Reflect;
+use trie_rs::map::Trie;
+
+#[derive(Resource)]
+pub(crate) struct StateInspectors {
+    pub(crate) names: Trie<u8, usize>,
+    pub(crate) visible: Vec<bool>,
+}
+
+pub struct StateInspectorActs {
+    plugins: Option<PluginGroupBuilder>,
+    state_names: Vec<String>,
+    acts: Acts,
+}
+
+impl ActsPluginGroup for StateInspectorActs {
+    fn acts(&self) -> &Acts {
+        &self.acts
+    }
+
+    fn acts_mut(&mut self) -> &mut Acts {
+        &mut self.acts
+    }
+}
+
+impl StateInspectorActs {
+    pub fn add<S: FreelyMutableState + Reflect>(mut self) -> Self {
+        let index = self.state_names.len();
+        self.state_names.push(pretty_type_name::<S>());
+        self.add_plugin(state_inspector_plugin::<S>(index));
+        self
+    }
+
+    fn add_plugin<T: Plugin>(&mut self, plugin: T) {
+        let builder = self.plugins.take().expect("plugin builder");
+        self.plugins = Some(builder.add(plugin));
+    }
+}
+
+fn state_inspector(states: Res<StateInspectors>,
+                      mut minibuffer: Minibuffer) {
+    if !states.visible.is_empty() {
+        minibuffer.prompt_map("state: ", states.names.clone())
+            .observe(|mut trigger: Trigger<Completed<usize>>,
+                     mut states: ResMut<StateInspectors>,
+                     mut minibuffer: Minibuffer| {
+                         if let Ok(index) = trigger.event_mut().take_result().unwrap() {
+                             states.visible[index] = !states.visible[index];
+                         }
+            });
+    } else {
+        minibuffer.message("No states registered.");
+    }
+}
+
+impl Default for StateInspectorActs {
+    fn default() -> Self {
+        Self {
+            plugins: Some(PluginGroupBuilder::start::<Self>()),
+            state_names: vec![],
+            acts: Acts::new([Act::new(state_inspector)])
+        }
+    }
+}
+
+impl PluginGroup for StateInspectorActs {
+    fn build(mut self) -> PluginGroupBuilder {
+        let builder = self.plugins.take().expect("plugin builder");
+        self.warn_on_unused_acts();
+        builder.add(move |app: &mut App| {
+            let count = self.state_names.len();
+            let trie = Trie::from_iter(self.state_names.clone().into_iter().enumerate().map(|(index, name)| (name, index)));
+            app.insert_resource(StateInspectors {
+                names: trie,
+                visible: vec![false; count],
+            });
+        })
+    }
+}
+
+fn state_visible(index: usize) -> impl Fn(Res<StateInspectors>) -> bool {
+    move |inspectors: Res<StateInspectors>| {
+        inspectors.visible.get(index).copied().unwrap_or(false)
+    }
+}
+
+fn state_inspector_plugin<A: FreelyMutableState + Reflect>(index: usize) -> impl Fn(&mut App) {
+    move |app: &mut App| {
+        app.add_plugins(StateInspectorPlugin::<A>::default()
+                    .run_if(in_state(PromptState::Visible).and(state_visible(index)))
+        );
+    }
+}

--- a/crates/bevy-inspector-egui/src/minibuffer/state_inspector.rs
+++ b/crates/bevy-inspector-egui/src/minibuffer/state_inspector.rs
@@ -1,28 +1,3 @@
-//! # state_inspector act
-//!
-//! ## Usage
-//!
-//! ```no_run
-//! use bevy::prelude::*;
-//! use bevy_minibuffer::prelude::*;
-//! use bevy_inspector_egui::minibuffer;
-//! #[derive(States, Default, Debug, Clone, Eq, PartialEq, Hash, Reflect)]
-//! enum AppState {
-//!     #[default]
-//!     A,
-//!     B,
-//!     C,
-//! }
-//! fn plugin(app: &mut App) {
-//!     app
-//!         .add_plugins(MinibufferPlugins)
-//!         .add_acts((
-//!             BasicActs::default(),
-//!             minibuffer::StateInspectorActs::default()
-//!                 .add::<AppState>()
-//!         ));
-//! }
-//! ```
 use crate::{
     minibuffer::{InspectorPlugins, Inspectors},
     quick::StateInspectorPlugin,
@@ -37,7 +12,33 @@ use bevy_minibuffer::{prelude::*, prompt::PromptState};
 use bevy_reflect::Reflect;
 use bevy_state::{prelude::in_state, state::FreelyMutableState};
 
-/// Adds the 'state_inspector' act which toggles the visibility of registered state inspectors.
+/// ## Adds the 'state_inspector' act
+///
+/// This act toggles the visibility of registered state inspectors.
+///
+/// ## Usage
+///
+/// ```no_run
+/// use bevy::prelude::*;
+/// use bevy_minibuffer::prelude::*;
+/// use bevy_inspector_egui::minibuffer;
+/// #[derive(States, Default, Debug, Clone, Eq, PartialEq, Hash, Reflect)]
+/// enum AppState {
+///     #[default]
+///     A,
+///     B,
+///     C,
+/// }
+/// fn plugin(app: &mut App) {
+///     app
+///         .add_plugins(MinibufferPlugins)
+///         .add_acts((
+///             BasicActs::default(),
+///             minibuffer::StateInspectorActs::default()
+///                 .add::<AppState>()
+///         ));
+/// }
+/// ```
 pub struct StateInspectorActs {
     plugins: InspectorPlugins<Self>,
     acts: Acts,
@@ -46,6 +47,7 @@ pub struct StateInspectorActs {
 impl PluginGroup for StateInspectorActs {
     fn build(self) -> PluginGroupBuilder {
         self.warn_on_unused_acts();
+        self.plugins.warn_on_empty("No states registered with `StateInspectorActs`; consider adding some.");
         self.plugins.build()
     }
 }
@@ -101,8 +103,9 @@ impl Default for StateInspectorActs {
     fn default() -> Self {
         Self {
             plugins: InspectorPlugins::default(),
-            acts: Acts::new([Act::new(state_inspector)]), // acts: Acts::new([Act::new(InspectorPlugins::<StateInspectorActs>::inspector("state: ", "No states registered"))
-                                                          // .named("state_inspector")])
+            acts: Acts::new([Act::new(state_inspector)]),
+            // acts: Acts::new([Act::new(InspectorPlugins::<StateInspectorActs>::inspector("state: ", "No states registered"))
+            // .named("state_inspector")])
         }
     }
 }

--- a/crates/bevy-inspector-egui/src/minibuffer/state_inspector.rs
+++ b/crates/bevy-inspector-egui/src/minibuffer/state_inspector.rs
@@ -47,7 +47,8 @@ pub struct StateInspectorActs {
 impl PluginGroup for StateInspectorActs {
     fn build(self) -> PluginGroupBuilder {
         self.warn_on_unused_acts();
-        self.plugins.warn_on_empty("No states registered with `StateInspectorActs`; consider adding some.");
+        self.plugins
+            .warn_on_empty("No states registered with `StateInspectorActs`; consider adding some.");
         self.plugins.build()
     }
 }

--- a/crates/bevy-inspector-egui/src/minibuffer/state_inspector.rs
+++ b/crates/bevy-inspector-egui/src/minibuffer/state_inspector.rs
@@ -1,3 +1,28 @@
+//! # state_inspector act
+//!
+//! ## Usage
+//!
+//! ```no_run
+//! use bevy::prelude::*;
+//! use bevy_minibuffer::prelude::*;
+//! use bevy_inspector_egui::minibuffer;
+//! #[derive(States, Default, Debug, Clone, Eq, PartialEq, Hash, Reflect)]
+//! enum AppState {
+//!     #[default]
+//!     A,
+//!     B,
+//!     C,
+//! }
+//! fn plugin(app: &mut App) {
+//!     app
+//!         .add_plugins(MinibufferPlugins)
+//!         .add_acts((
+//!             BasicActs::default(),
+//!             minibuffer::StateInspectorActs::default()
+//!                 .add::<AppState>()
+//!         ));
+//! }
+//! ```
 use crate::{
     minibuffer::{InspectorPlugins, Inspectors},
     quick::StateInspectorPlugin,
@@ -12,6 +37,7 @@ use bevy_minibuffer::{prelude::*, prompt::PromptState};
 use bevy_reflect::Reflect;
 use bevy_state::{prelude::in_state, state::FreelyMutableState};
 
+/// Adds the 'state_inspector' act which toggles the visibility of registered state inspectors.
 pub struct StateInspectorActs {
     plugins: InspectorPlugins<Self>,
     acts: Acts,
@@ -35,6 +61,7 @@ impl ActsPluginGroup for StateInspectorActs {
 }
 
 impl StateInspectorActs {
+    /// Add a state to the list of inspectors when prompted.
     pub fn add<S: FreelyMutableState + Reflect>(mut self) -> Self {
         self.plugins
             .add_inspector(pretty_type_name::<S>(), Self::add_plugin::<S>);

--- a/crates/bevy-inspector-egui/src/minibuffer/state_inspector.rs
+++ b/crates/bevy-inspector-egui/src/minibuffer/state_inspector.rs
@@ -4,6 +4,7 @@ use bevy_minibuffer::{prelude::*, prompt::PromptState};
 use crate::{
     quick::{WorldInspectorPlugin, StateInspectorPlugin},
     utils::pretty_type_name,
+    minibuffer::{InspectorPlugins, Inspectors},
 };
 use bevy_ecs::{prelude::{Resource, Res, ResMut, World, Trigger}, schedule::Condition};
 use bevy_state::app::AppExtStates;
@@ -12,16 +13,16 @@ use bevy_egui::EguiContext;
 use bevy_reflect::Reflect;
 use trie_rs::map::Trie;
 
-#[derive(Resource)]
-pub(crate) struct StateInspectors {
-    pub(crate) names: Trie<u8, usize>,
-    pub(crate) visible: Vec<bool>,
+pub struct StateInspectorActs {
+    plugins: InspectorPlugins<Self>,
+    acts: Acts,
 }
 
-pub struct StateInspectorActs {
-    plugins: Option<PluginGroupBuilder>,
-    state_names: Vec<String>,
-    acts: Acts,
+impl PluginGroup for StateInspectorActs {
+    fn build(mut self) -> PluginGroupBuilder {
+        self.warn_on_unused_acts();
+        self.plugins.build()
+    }
 }
 
 impl ActsPluginGroup for StateInspectorActs {
@@ -36,24 +37,23 @@ impl ActsPluginGroup for StateInspectorActs {
 
 impl StateInspectorActs {
     pub fn add<S: FreelyMutableState + Reflect>(mut self) -> Self {
-        let index = self.state_names.len();
-        self.state_names.push(pretty_type_name::<S>());
-        self.add_plugin(state_inspector_plugin::<S>(index));
+        self.plugins
+            .add_inspector(pretty_type_name::<S>(), Self::add_plugin::<S>);
         self
     }
 
-    fn add_plugin<T: Plugin>(&mut self, plugin: T) {
-        let builder = self.plugins.take().expect("plugin builder");
-        self.plugins = Some(builder.add(plugin));
+    fn add_plugin<A: FreelyMutableState + Reflect>(index: usize, inspector_plugins: &mut InspectorPlugins<Self>) {
+        inspector_plugins.add_plugin(StateInspectorPlugin::<A>::default()
+                                     .run_if(in_state(PromptState::Visible).and(InspectorPlugins::<Self>::visible(index))));
     }
 }
 
-fn state_inspector(states: Res<StateInspectors>,
-                      mut minibuffer: Minibuffer) {
+fn state_inspector(states: Res<Inspectors<StateInspectorActs>>,
+                   mut minibuffer: Minibuffer) {
     if !states.visible.is_empty() {
         minibuffer.prompt_map("state: ", states.names.clone())
             .observe(|mut trigger: Trigger<Completed<usize>>,
-                     mut states: ResMut<StateInspectors>,
+                     mut states: ResMut<Inspectors<StateInspectorActs>>,
                      mut minibuffer: Minibuffer| {
                          if let Ok(index) = trigger.event_mut().take_result().unwrap() {
                              states.visible[index] = !states.visible[index];
@@ -67,38 +67,10 @@ fn state_inspector(states: Res<StateInspectors>,
 impl Default for StateInspectorActs {
     fn default() -> Self {
         Self {
-            plugins: Some(PluginGroupBuilder::start::<Self>()),
-            state_names: vec![],
+            plugins: InspectorPlugins::default(),
             acts: Acts::new([Act::new(state_inspector)])
+            // acts: Acts::new([Act::new(InspectorPlugins::<StateInspectorActs>::inspector("state: ", "No states registered"))
+            // .named("state_inspector")])
         }
-    }
-}
-
-impl PluginGroup for StateInspectorActs {
-    fn build(mut self) -> PluginGroupBuilder {
-        let builder = self.plugins.take().expect("plugin builder");
-        self.warn_on_unused_acts();
-        builder.add(move |app: &mut App| {
-            let count = self.state_names.len();
-            let trie = Trie::from_iter(self.state_names.clone().into_iter().enumerate().map(|(index, name)| (name, index)));
-            app.insert_resource(StateInspectors {
-                names: trie,
-                visible: vec![false; count],
-            });
-        })
-    }
-}
-
-fn state_visible(index: usize) -> impl Fn(Res<StateInspectors>) -> bool {
-    move |inspectors: Res<StateInspectors>| {
-        inspectors.visible.get(index).copied().unwrap_or(false)
-    }
-}
-
-fn state_inspector_plugin<A: FreelyMutableState + Reflect>(index: usize) -> impl Fn(&mut App) {
-    move |app: &mut App| {
-        app.add_plugins(StateInspectorPlugin::<A>::default()
-                    .run_if(in_state(PromptState::Visible).and(state_visible(index)))
-        );
     }
 }

--- a/crates/bevy-inspector-egui/src/minibuffer/world_inspector.rs
+++ b/crates/bevy-inspector-egui/src/minibuffer/world_inspector.rs
@@ -1,20 +1,3 @@
-//! # world_inspector act
-//!
-//! ## Usage
-//!
-//! ```no_run
-//! use bevy::prelude::*;
-//! use bevy_minibuffer::prelude::*;
-//! use bevy_inspector_egui::minibuffer;
-//! fn plugin(app: &mut App) {
-//!     app
-//!         .add_plugins(MinibufferPlugins)
-//!         .add_acts((
-//!             BasicActs::default(),
-//!             minibuffer::WorldInspectorActs::default(),
-//!         ));
-//! }
-//! ```
 use crate::quick::WorldInspectorPlugin;
 use bevy_app::{App, Plugin};
 use bevy_ecs::{
@@ -37,8 +20,25 @@ enum WorldInspectorState {
     Visible,
 }
 
-/// Provides the 'world_inspector' act that toggles the visibility of the world
-/// inspector.
+/// ## Adds the 'world_inspector' act
+///
+/// This act toggles the visibility of the world inspector.
+///
+/// ## Usage
+///
+/// ```no_run
+/// use bevy::prelude::*;
+/// use bevy_minibuffer::prelude::*;
+/// use bevy_inspector_egui::minibuffer;
+/// fn plugin(app: &mut App) {
+///     app
+///         .add_plugins(MinibufferPlugins)
+///         .add_acts((
+///             BasicActs::default(),
+///             minibuffer::WorldInspectorActs::default(),
+///         ));
+/// }
+/// ```
 pub struct WorldInspectorActs {
     acts: Acts,
 }

--- a/crates/bevy-inspector-egui/src/minibuffer/world_inspector.rs
+++ b/crates/bevy-inspector-egui/src/minibuffer/world_inspector.rs
@@ -1,0 +1,86 @@
+//! # world_inspector act
+//!
+//! ## Usage
+//!
+//! ```no_run
+//! use bevy::prelude::*;
+//! use bevy_minibuffer::prelude::*;
+//! use bevy_inspector_egui::minibuffer;
+//! fn plugin(app: &mut App) {
+//!     app
+//!         .add_plugins(MinibufferPlugins)
+//!         .add_acts((
+//!             BasicActs::default(),
+//!             minibuffer::WorldInspectorActs::default(),
+//!         ));
+//! }
+//! ```
+use crate::quick::WorldInspectorPlugin;
+use bevy_app::{App, Plugin};
+use bevy_ecs::{
+    prelude::{Res, ResMut},
+    schedule::Condition,
+};
+use bevy_minibuffer::{prelude::*, prompt::PromptState};
+use bevy_reflect::Reflect;
+use bevy_state::app::AppExtStates;
+use bevy_state::prelude::in_state;
+use bevy_state::prelude::{NextState, State, States};
+
+/// Is the prompt visible?
+#[derive(Debug, Clone, Copy, Default, Eq, PartialEq, Hash, States, Reflect)]
+enum WorldInspectorState {
+    /// Invisible
+    #[default]
+    Invisible,
+    /// Visible
+    Visible,
+}
+
+/// Provides the 'world_inspector' act that toggles the visibility of the world
+/// inspector.
+pub struct WorldInspectorActs {
+    acts: Acts,
+}
+
+impl ActsPlugin for WorldInspectorActs {
+    fn acts(&self) -> &Acts {
+        &self.acts
+    }
+    fn acts_mut(&mut self) -> &mut Acts {
+        &mut self.acts
+    }
+}
+
+fn world_inspector(
+    state: Res<State<WorldInspectorState>>,
+    mut next_state: ResMut<NextState<WorldInspectorState>>,
+    mut minibuffer: Minibuffer,
+) {
+    use WorldInspectorState::*;
+    let (state, msg) = match state.get() {
+        Invisible => (Visible, "Show world inspector"),
+        Visible => (Invisible, "Hide world inspector"),
+    };
+    next_state.set(state);
+    minibuffer.message(msg);
+}
+
+impl Default for WorldInspectorActs {
+    fn default() -> Self {
+        Self {
+            acts: Acts::new([Act::new(world_inspector)]),
+        }
+    }
+}
+
+impl Plugin for WorldInspectorActs {
+    fn build(&self, app: &mut App) {
+        app.add_plugins(
+            WorldInspectorPlugin::default()
+                .run_if(in_state(PromptState::Visible).and(in_state(WorldInspectorState::Visible))),
+        )
+        .init_state::<WorldInspectorState>();
+        self.warn_on_unused_acts();
+    }
+}


### PR DESCRIPTION
Hi Jakob,

I'm a big fan of bevy-inspector-egui. I just released [bevy_minibuffer](https://github.com/shanecelis/bevy_minibuffer), which is a gamedev console. Because I'm always reaching for bevy-inspector, I thought I'd try to integrate it with minibuffer. I've added a few posts with videos to bevy's discord #showcase: [post 1](https://discord.com/channels/691052431525675048/692648638823923732/1316712641254920213) and [post 2](https://discord.com/channels/691052431525675048/692648638823923732/1317113190244679760). You can play with the example:

```sh
cargo run --example minibuffer --feature minibuffer
```

This pull request isn't really ready to merge. I'd more like to invite a discussion as to where you think this functionality should go? The options I've considered for minibuffer integrations are these:

1. bevy-inspector-egui adds a "minibuffer" feature flag.
2. bevy_minibuffer adds a "bevy-inspector-egui" feature flag.
3. A new crate with the integration is published named?
  - bevy-inspector-egui-minibuffer
  - bevy_minibuffer_inspector
  - bevy_minibuffer_inspector_egui
  - bevy_minibuffer_inspectors

This PR is currently in the mold of option 1. but I feel like there are a number of cons: 
- It introduced three new optional dependencies. 
- bevy_minibuffer is new and unstable, and bevy_inspector_egui feels kind of crucial for bevy users. It's one of the crates I want to see updated quickly when bevy releases a new minor version. I wouldn't want to delay bevy_inspector_egui's release on account of bevy_minibuffer.

Option 2. doesn't seem bad but would probably just be a stop gap before going ultimately to option 3.

So in writing this up I think I've convinced myself that option 3. is probably best. Still I'd be happy to hear what kind of "_mod_" crate names you'd choose for bevy_inspector_egui.

Thanks for your time.

-Shane