### PR TITLE
Custom filters and Hierarchy support

### DIFF
--- a/crates/bevy-inspector-egui/src/bevy_inspector/hierarchy.rs
+++ b/crates/bevy-inspector-egui/src/bevy_inspector/hierarchy.rs
@@ -74,8 +74,8 @@ impl<T> Hierarchy<'_, T> {
             })
             .collect();
 
-        let entities: Vec<_> = root_query.iter(self.world).collect();
-        let mut entities = filter.filtered_entities(self.world, entities);
+        let mut entities: Vec<_> = root_query.iter(self.world).collect();
+        filter.filter_entities(self.world, &mut entities);
         entities.sort();
 
         let mut selected = false;
@@ -151,9 +151,9 @@ impl<T> Hierarchy<'_, T> {
             .show(ui, |ui| {
                 let children = self.world.get::<Children>(entity);
                 if let Some(children) = children {
-                    let children = children.to_vec();
-                    let children = filter.filtered_entities(self.world, children);
-                    for &child in children.iter() {
+                    let mut children = children.to_vec();
+                    filter.filter_entities(self.world, &mut children);
+                    for &child in &children {
                         new_selection |=
                             self.entity_ui_with_filter(ui, child, always_open, &children, filter);
                     }

--- a/crates/bevy-inspector-egui/src/bevy_inspector/hierarchy.rs
+++ b/crates/bevy-inspector-egui/src/bevy_inspector/hierarchy.rs
@@ -84,9 +84,6 @@ impl<T> Hierarchy<'_, T> {
         }
         selected
     }
-    fn is_selected(&self, entity: Entity) -> bool {
-        self.selected.contains(entity)
-    }
 
     fn entity_ui_with_filter<F>(
         &mut self,
@@ -114,7 +111,7 @@ impl<T> Hierarchy<'_, T> {
         F: EntityFilter + Clone,
     {
         let mut new_selection = false;
-        let selected = self.is_selected(entity);
+        let selected = self.selected.contains(entity);
 
         let entity_name = guess_entity_name::guess_entity_name(self.world, entity);
         let mut name = RichText::new(entity_name);

--- a/crates/bevy-inspector-egui/src/bevy_inspector/hierarchy.rs
+++ b/crates/bevy-inspector-egui/src/bevy_inspector/hierarchy.rs
@@ -56,7 +56,7 @@ impl<T> Hierarchy<'_, T> {
     {
         self._show::<QF, F>(ui, filter)
     }
-    pub fn _show<QF, F>(&mut self, ui: &mut egui::Ui, filter: F) -> bool
+    fn _show<QF, F>(&mut self, ui: &mut egui::Ui, filter: F) -> bool
     where
         QF: QueryFilter,
         F: EntityFilter + Clone,

--- a/crates/bevy-inspector-egui/src/bevy_inspector/hierarchy.rs
+++ b/crates/bevy-inspector-egui/src/bevy_inspector/hierarchy.rs
@@ -40,13 +40,14 @@ impl<T> Hierarchy<'_, T> {
     where
         QF: QueryFilter,
     {
-        self._show::<QF, _>(ui, Filter::empty())
+        let filter: Filter = Filter::all();
+        self._show::<QF, _>(ui, filter)
     }
     pub fn show_with_default_filter<QF>(&mut self, ui: &mut egui::Ui) -> bool
     where
         QF: QueryFilter,
     {
-        let filter = Filter::from_ui(ui, egui::Id::new("default_hierarchy_filter"));
+        let filter: Filter = Filter::from_ui(ui, egui::Id::new("default_hierarchy_filter"));
         self._show::<QF, _>(ui, filter)
     }
     pub fn show_with_filter<QF, F>(&mut self, ui: &mut egui::Ui, filter: F) -> bool

--- a/crates/bevy-inspector-egui/src/bevy_inspector/hierarchy.rs
+++ b/crates/bevy-inspector-egui/src/bevy_inspector/hierarchy.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-use crate::bevy_inspector::{EntityFilter, Filter, FilterFromUiId};
+use crate::bevy_inspector::{EntityFilter, Filter};
 use crate::utils::guess_entity_name;
 use bevy_ecs::{prelude::*, query::QueryFilter};
 use bevy_hierarchy::{Children, Parent};
@@ -48,10 +48,7 @@ impl<T> Hierarchy<'_, T> {
     {
         let filter = Filter::from_ui(
             ui,
-            FilterFromUiId {
-                filter_string_id: "hierarchy_filter_string_id".into(),
-                is_fuzzy_id: "hierarchy_is_fuzzy_id".into(),
-            },
+            egui::Id::new("default_hierarchy_filter"),
         );
         self._show::<QF, _>(ui, filter)
     }

--- a/crates/bevy-inspector-egui/src/bevy_inspector/hierarchy.rs
+++ b/crates/bevy-inspector-egui/src/bevy_inspector/hierarchy.rs
@@ -42,7 +42,7 @@ impl<T> Hierarchy<'_, T> {
     {
         self._show::<QF, _>(ui, Filter::empty())
     }
-    pub fn show_with_filter_from_ui<QF>(&mut self, ui: &mut egui::Ui) -> bool
+    pub fn show_with_default_filter<QF>(&mut self, ui: &mut egui::Ui) -> bool
     where
         QF: QueryFilter,
     {

--- a/crates/bevy-inspector-egui/src/bevy_inspector/hierarchy.rs
+++ b/crates/bevy-inspector-egui/src/bevy_inspector/hierarchy.rs
@@ -55,14 +55,14 @@ impl<T> Hierarchy<'_, T> {
     pub fn show_with_filter<QF, F>(&mut self, ui: &mut egui::Ui, filter: F) -> bool
     where
         QF: QueryFilter,
-        F: EntityFilter + Clone,
+        F: EntityFilter,
     {
         self._show::<QF, F>(ui, filter)
     }
     fn _show<QF, F>(&mut self, ui: &mut egui::Ui, filter: F) -> bool
     where
         QF: QueryFilter,
-        F: EntityFilter + Clone,
+        F: EntityFilter,
     {
         let mut root_query = self.world.query_filtered::<Entity, (Without<Parent>, QF)>();
 
@@ -97,7 +97,7 @@ impl<T> Hierarchy<'_, T> {
         filter: &F,
     ) -> bool
     where
-        F: EntityFilter + Clone,
+        F: EntityFilter,
     {
         self._entity_ui(ui, entity, always_open, at_same_level, filter)
     }
@@ -111,7 +111,7 @@ impl<T> Hierarchy<'_, T> {
         filter: &F,
     ) -> bool
     where
-        F: EntityFilter + Clone,
+        F: EntityFilter,
     {
         let mut new_selection = false;
         let selected = self.selected.contains(entity);

--- a/crates/bevy-inspector-egui/src/bevy_inspector/hierarchy.rs
+++ b/crates/bevy-inspector-egui/src/bevy_inspector/hierarchy.rs
@@ -86,26 +86,12 @@ impl<T> Hierarchy<'_, T> {
 
         let mut selected = false;
         for &entity in &entities {
-            selected |= self.entity_ui_with_filter(ui, entity, &always_open, &entities, &filter);
+            selected |= self.entity_ui(ui, entity, &always_open, &entities, &filter);
         }
         selected
     }
 
-    fn entity_ui_with_filter<F>(
-        &mut self,
-        ui: &mut egui::Ui,
-        entity: Entity,
-        always_open: &HashSet<Entity>,
-        at_same_level: &[Entity],
-        filter: &F,
-    ) -> bool
-    where
-        F: EntityFilter,
-    {
-        self._entity_ui(ui, entity, always_open, at_same_level, filter)
-    }
-
-    fn _entity_ui<F>(
+    fn entity_ui<F>(
         &mut self,
         ui: &mut egui::Ui,
         entity: Entity,
@@ -161,7 +147,7 @@ impl<T> Hierarchy<'_, T> {
                     filter.filter_entities(self.world, &mut children);
                     for &child in &children {
                         new_selection |=
-                            self.entity_ui_with_filter(ui, child, always_open, &children, filter);
+                            self.entity_ui(ui, child, always_open, &children, filter);
                     }
                 } else {
                     ui.label("No children");

--- a/crates/bevy-inspector-egui/src/bevy_inspector/hierarchy.rs
+++ b/crates/bevy-inspector-egui/src/bevy_inspector/hierarchy.rs
@@ -46,10 +46,13 @@ impl<T> Hierarchy<'_, T> {
     where
         QF: QueryFilter,
     {
-        let filter = Filter::from_ui(ui, FilterFromUiId {
-            filter_string_id: "hierarchy_filter_string_id".into(),
-            is_fuzzy_id: "hierarchy_is_fuzzy_id".into(),
-        });
+        let filter = Filter::from_ui(
+            ui,
+            FilterFromUiId {
+                filter_string_id: "hierarchy_filter_string_id".into(),
+                is_fuzzy_id: "hierarchy_is_fuzzy_id".into(),
+            },
+        );
         self._show::<QF, _>(ui, filter)
     }
     pub fn show_with_filter<QF, F>(&mut self, ui: &mut egui::Ui, filter: F) -> bool

--- a/crates/bevy-inspector-egui/src/bevy_inspector/hierarchy.rs
+++ b/crates/bevy-inspector-egui/src/bevy_inspector/hierarchy.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-use crate::bevy_inspector::{EntityFilter, Filter};
+use crate::bevy_inspector::{EntityFilter, Filter, FilterFromUiId};
 use crate::utils::guess_entity_name;
 use bevy_ecs::{prelude::*, query::QueryFilter};
 use bevy_hierarchy::{Children, Parent};
@@ -46,7 +46,10 @@ impl<T> Hierarchy<'_, T> {
     where
         QF: QueryFilter,
     {
-        let filter = Filter::from_ui(ui);
+        let filter = Filter::from_ui(ui, FilterFromUiId {
+            filter_string_id: "hierarchy_filter_string_id".into(),
+            is_fuzzy_id: "hierarchy_is_fuzzy_id".into(),
+        });
         self._show::<QF, _>(ui, filter)
     }
     pub fn show_with_filter<QF, F>(&mut self, ui: &mut egui::Ui, filter: F) -> bool

--- a/crates/bevy-inspector-egui/src/bevy_inspector/hierarchy.rs
+++ b/crates/bevy-inspector-egui/src/bevy_inspector/hierarchy.rs
@@ -46,10 +46,7 @@ impl<T> Hierarchy<'_, T> {
     where
         QF: QueryFilter,
     {
-        let filter = Filter::from_ui(
-            ui,
-            egui::Id::new("default_hierarchy_filter"),
-        );
+        let filter = Filter::from_ui(ui, egui::Id::new("default_hierarchy_filter"));
         self._show::<QF, _>(ui, filter)
     }
     pub fn show_with_filter<QF, F>(&mut self, ui: &mut egui::Ui, filter: F) -> bool
@@ -143,8 +140,7 @@ impl<T> Hierarchy<'_, T> {
                     let mut children = children.to_vec();
                     filter.filter_entities(self.world, &mut children);
                     for &child in &children {
-                        new_selection |=
-                            self.entity_ui(ui, child, always_open, &children, filter);
+                        new_selection |= self.entity_ui(ui, child, always_open, &children, filter);
                     }
                 } else {
                     ui.label("No children");

--- a/crates/bevy-inspector-egui/src/bevy_inspector/mod.rs
+++ b/crates/bevy-inspector-egui/src/bevy_inspector/mod.rs
@@ -26,7 +26,7 @@
 //!     egui::CollapsingHeader::new("Entities")
 //!         .default_open(true)
 //!         .show(ui, |ui| {
-//!             bevy_inspector::ui_for_world_entities(world, ui);
+//!             bevy_inspector::ui_for_entities(world, ui);
 //!         });
 //!     egui::CollapsingHeader::new("Resources").show(ui, |ui| {
 //!         bevy_inspector::ui_for_resources(world, ui);

--- a/crates/bevy-inspector-egui/src/bevy_inspector/mod.rs
+++ b/crates/bevy-inspector-egui/src/bevy_inspector/mod.rs
@@ -389,7 +389,7 @@ pub fn ui_for_world_entities_with_filter<QF, F>(
     filter: &F,
 ) where
     QF: WorldQuery + QueryFilter,
-    F: EntityFilter + Clone,
+    F: EntityFilter,
 {
     let type_registry = world.resource::<AppTypeRegistry>().0.clone();
     let type_registry = type_registry.read();
@@ -489,7 +489,7 @@ fn ui_for_entity_with_children_inner<F>(
     type_registry: &TypeRegistry,
     filter: &F,
 ) where
-    F: EntityFilter + Clone,
+    F: EntityFilter,
 {
     let mut queue = CommandQueue::default();
     ui_for_entity_components(

--- a/crates/bevy-inspector-egui/src/bevy_inspector/mod.rs
+++ b/crates/bevy-inspector-egui/src/bevy_inspector/mod.rs
@@ -243,20 +243,22 @@ pub fn ui_for_world_entities(world: &mut World, ui: &mut egui::Ui) {
 }
 
 pub trait EntityFilter {
-    const EMPTY_IS_NOOP: bool = true;
-
-    /// Returns true if the filter term is currently empty
+    /// Returns true if the filter term is currently active
     ///
-    /// default impl is false
-    fn is_empty(&self) -> bool {
-        false
+    /// Used in the default impl of [`EntityFilter::filter_entities`] to skip filtering if false
+    ///
+    /// default impl is true
+    fn is_active(&self) -> bool {
+        true
     }
 
     /// Filters entities in place
     ///
-    /// default impl using [`EntityFilter::filter_entity`] to mark what entities to retain
+    /// default impl:
+    /// - uses [`EntityFilter::filter_entity`] to mark what entities to retain
+    /// - skips filtering if [`EntityFilter::is_active`] returns false
     fn filter_entities(&self, world: &mut World, entities: &mut Vec<Entity>) {
-        if self.is_empty() && Self::EMPTY_IS_NOOP {
+        if !self.is_active() {
             return;
         }
         entities.retain(|&entity| self.filter_entity(world, entity));
@@ -336,8 +338,8 @@ impl Filter {
 }
 
 impl EntityFilter for Filter {
-    fn is_empty(&self) -> bool {
-        self.word.is_empty()
+    fn is_active(&self) -> bool {
+        !self.word.is_empty()
     }
 
     fn filter_entity(&self, world: &mut World, entity: Entity) -> bool {

--- a/crates/bevy-inspector-egui/src/bevy_inspector/mod.rs
+++ b/crates/bevy-inspector-egui/src/bevy_inspector/mod.rs
@@ -238,6 +238,8 @@ pub fn ui_for_state<T: FreelyMutableState + Reflect>(world: &mut World, ui: &mut
 }
 
 /// Display all entities matching [`Without<Parent>`] and their components
+///
+/// Includes basic [`EntityFilter`]
 #[deprecated(
     since = "0.28.1",
     note = "use ui_for_entities instead"
@@ -247,10 +249,11 @@ pub fn ui_for_world_entities(world: &mut World, ui: &mut egui::Ui) {
 }
 
 /// Display all entities matching [`Without<Parent>`] and their components
+///
+/// Includes basic [`EntityFilter`]
 pub fn ui_for_entities(world: &mut World, ui: &mut egui::Ui) {
     ui_for_entities_filtered_with_default_filter::<Without<Parent>>(world, ui, true);
 }
-
 
 /// Display all entities matching the static [`QueryFilter`]
 #[deprecated(
@@ -274,16 +277,19 @@ pub fn ui_for_entities_filtered<QF: WorldQuery + QueryFilter>(
     ui_for_entities_filtered_with_filter::<QF, _>(world, ui, with_children, &Filter::empty());
 }
 
-/// Display all entities matching the static [`QueryFilter`]
+/// Display all entities matching [`Without<Parent>`] and the provided [`EntityFilter`]
 pub fn ui_for_entities_with_filter<F: EntityFilter>(
     world: &mut World,
     ui: &mut egui::Ui,
     with_children: bool,
+    filter: &F,
 ) {
-    ui_for_entities_filtered_with_filter::<Without<Parent>, F>(world, ui, with_children, &Filter::empty());
+    ui_for_entities_filtered_with_filter::<Without<Parent>, F>(world, ui, with_children, &filter);
 }
 
-/// Display all entities matching the inner managed filter ui
+/// Display all entities matching the static [`QueryFilter`]
+///
+/// Includes basic [`EntityFilter`]
 pub fn ui_for_entities_filtered_with_default_filter<QF: WorldQuery + QueryFilter>(
     world: &mut World,
     ui: &mut egui::Ui,

--- a/crates/bevy-inspector-egui/src/bevy_inspector/mod.rs
+++ b/crates/bevy-inspector-egui/src/bevy_inspector/mod.rs
@@ -270,7 +270,7 @@ pub trait EntityFilter {
     fn filter_entity(
         &self,
         world: &mut World,
-        entities: Entity,
+        entity: Entity,
     ) -> bool;
 }
 

--- a/crates/bevy-inspector-egui/src/bevy_inspector/mod.rs
+++ b/crates/bevy-inspector-egui/src/bevy_inspector/mod.rs
@@ -249,7 +249,7 @@ pub trait EntityFilter {
     fn is_empty(&self) -> bool {
         false
     }
-    /// Returns [`FilteredEntities`]
+    /// Returns [`Vec<Entity>`] filtered by the filter term
     fn filtered_entities(
         &self,
         world: &mut World,

--- a/crates/bevy-inspector-egui/src/bevy_inspector/mod.rs
+++ b/crates/bevy-inspector-egui/src/bevy_inspector/mod.rs
@@ -255,11 +255,7 @@ pub trait EntityFilter {
     /// Filters entities in place
     ///
     /// default impl using [`EntityFilter::filter_entity`] to mark what entities to retain
-    fn filter_entities(
-        &self,
-        world: &mut World,
-        entities: &mut Vec<Entity>,
-    ) {
+    fn filter_entities(&self, world: &mut World, entities: &mut Vec<Entity>) {
         if self.is_empty() && Self::EMPTY_IS_NOOP {
             return;
         }
@@ -267,11 +263,7 @@ pub trait EntityFilter {
     }
 
     /// Returns true if entity matches the filter term
-    fn filter_entity(
-        &self,
-        world: &mut World,
-        entity: Entity,
-    ) -> bool;
+    fn filter_entity(&self, world: &mut World, entity: Entity) -> bool;
 }
 
 /// Helps [`Filter::from_ui`] determine what global egui id's to use for its ui state.
@@ -301,12 +293,16 @@ impl Filter {
         let word = {
             // filter, using eguis memory and provided id
             let mut filter_string = ui.memory_mut(|mem| {
-                let filter: &mut String = mem.data.get_persisted_mut_or_default(filter_from_ui_id.filter_string_id);
+                let filter: &mut String = mem
+                    .data
+                    .get_persisted_mut_or_default(filter_from_ui_id.filter_string_id);
                 filter.clone()
             });
             ui.text_edit_singleline(&mut filter_string);
             ui.memory_mut(|mem| {
-                *mem.data.get_persisted_mut_or_default(filter_from_ui_id.filter_string_id) = filter_string.clone();
+                *mem.data
+                    .get_persisted_mut_or_default(filter_from_ui_id.filter_string_id) =
+                    filter_string.clone();
             });
 
             // improves overall matching
@@ -344,17 +340,8 @@ impl EntityFilter for Filter {
         self.word.is_empty()
     }
 
-    fn filter_entity(
-        &self,
-        world: &mut World,
-        entity: Entity,
-    ) -> bool {
-        self_or_children_satisfy_filter(
-            world,
-            entity,
-            self.word.as_str(),
-            self.is_fuzzy,
-        )
+    fn filter_entity(&self, world: &mut World, entity: Entity) -> bool {
+        self_or_children_satisfy_filter(world, entity, self.word.as_str(), self.is_fuzzy)
     }
 }
 

--- a/crates/bevy-inspector-egui/src/bevy_inspector/mod.rs
+++ b/crates/bevy-inspector-egui/src/bevy_inspector/mod.rs
@@ -381,37 +381,39 @@ pub struct Filter {
 
 impl Filter {
     pub fn from_ui(ui: &mut egui::Ui, id: egui::Id) -> Self {
-        let word = {
-            let id = id.with("word");
-            // filter, using eguis memory and provided id
-            let mut filter_string = ui.memory_mut(|mem| {
-                let filter: &mut String = mem.data.get_persisted_mut_or_default(id);
-                filter.clone()
-            });
-            ui.text_edit_singleline(&mut filter_string);
-            ui.memory_mut(|mem| {
-                *mem.data.get_persisted_mut_or_default(id) = filter_string.clone();
-            });
+        ui.horizontal(|ui| {
+            // filter kind
+            let is_fuzzy = {
+                let id = id.with("is_fuzzy");
+                let mut is_fuzzy = ui.memory_mut(|mem| {
+                    let fuzzy: &mut bool = mem.data.get_persisted_mut_or_default(id);
+                    *fuzzy
+                });
+                ui.checkbox(&mut is_fuzzy, "Fuzzy");
+                ui.memory_mut(|mem| {
+                    *mem.data.get_persisted_mut_or_default(id) = is_fuzzy;
+                });
+                is_fuzzy
+            };
+            let word = {
+                let id = id.with("word");
+                // filter, using eguis memory and provided id
+                let mut filter_string = ui.memory_mut(|mem| {
+                    let filter: &mut String = mem.data.get_persisted_mut_or_default(id);
+                    filter.clone()
+                });
+                ui.text_edit_singleline(&mut filter_string);
+                ui.memory_mut(|mem| {
+                    *mem.data.get_persisted_mut_or_default(id) = filter_string.clone();
+                });
 
-            // improves overall matching
-            filter_string.to_lowercase()
-        };
+                // improves overall matching
+                filter_string.to_lowercase()
+            };
 
-        // filter kind
-        let is_fuzzy = {
-            let id = id.with("is_fuzzy");
-            let mut is_fuzzy = ui.memory_mut(|mem| {
-                let fuzzy: &mut bool = mem.data.get_persisted_mut_or_default(id);
-                *fuzzy
-            });
-            ui.checkbox(&mut is_fuzzy, "Fuzzy Match");
-            ui.memory_mut(|mem| {
-                *mem.data.get_persisted_mut_or_default(id) = is_fuzzy;
-            });
-            is_fuzzy
-        };
-
-        Filter { word, is_fuzzy }
+            Filter { word, is_fuzzy }
+        })
+        .inner
     }
 
     /// empty filter which does nothing

--- a/crates/bevy-inspector-egui/src/bevy_inspector/mod.rs
+++ b/crates/bevy-inspector-egui/src/bevy_inspector/mod.rs
@@ -242,6 +242,21 @@ pub fn ui_for_world_entities(world: &mut World, ui: &mut egui::Ui) {
     ui_for_world_entities_filtered::<Without<Parent>>(world, ui, true);
 }
 
+pub trait EntityFilter {
+    /// Returns true if the filter term is currently empty
+    ///
+    /// default impl is false
+    fn is_empty(&self) -> bool {
+        false
+    }
+    /// Returns [`FilteredEntities`]
+    fn filtered_entities(
+        &self,
+        world: &mut World,
+        entities: impl IntoIterator<Item = Entity>,
+    ) -> Vec<Entity>;
+}
+
 #[derive(Debug, Clone)]
 pub struct Filter {
     pub word: String,

--- a/crates/bevy-inspector-egui/src/bevy_inspector/mod.rs
+++ b/crates/bevy-inspector-egui/src/bevy_inspector/mod.rs
@@ -240,10 +240,7 @@ pub fn ui_for_state<T: FreelyMutableState + Reflect>(world: &mut World, ui: &mut
 /// Display all entities matching [`Without<Parent>`] and their components
 ///
 /// Includes basic [`EntityFilter`]
-#[deprecated(
-    since = "0.28.1",
-    note = "use ui_for_entities instead"
-)]
+#[deprecated(since = "0.28.1", note = "use ui_for_entities instead")]
 pub fn ui_for_world_entities(world: &mut World, ui: &mut egui::Ui) {
     ui_for_entities(world, ui);
 }
@@ -256,10 +253,7 @@ pub fn ui_for_entities(world: &mut World, ui: &mut egui::Ui) {
 }
 
 /// Display all entities matching the static [`QueryFilter`]
-#[deprecated(
-    since = "0.28.1",
-    note = "use ui_for_entities_filtered instead"
-)]
+#[deprecated(since = "0.28.1", note = "use ui_for_entities_filtered instead")]
 pub fn ui_for_world_entities_filtered<QF: WorldQuery + QueryFilter>(
     world: &mut World,
     ui: &mut egui::Ui,
@@ -391,16 +385,12 @@ impl Filter {
             let id = id.with("word");
             // filter, using eguis memory and provided id
             let mut filter_string = ui.memory_mut(|mem| {
-                let filter: &mut String = mem
-                    .data
-                    .get_persisted_mut_or_default(id);
+                let filter: &mut String = mem.data.get_persisted_mut_or_default(id);
                 filter.clone()
             });
             ui.text_edit_singleline(&mut filter_string);
             ui.memory_mut(|mem| {
-                *mem.data
-                    .get_persisted_mut_or_default(id) =
-                    filter_string.clone();
+                *mem.data.get_persisted_mut_or_default(id) = filter_string.clone();
             });
 
             // improves overall matching

--- a/crates/bevy-inspector-egui/src/bevy_inspector/mod.rs
+++ b/crates/bevy-inspector-egui/src/bevy_inspector/mod.rs
@@ -243,9 +243,9 @@ pub fn ui_for_world_entities(world: &mut World, ui: &mut egui::Ui) {
 }
 
 #[derive(Debug, Clone)]
-struct Filter {
-    word: String,
-    is_fuzzy: bool,
+pub struct Filter {
+    pub word: String,
+    pub is_fuzzy: bool,
 }
 
 impl Filter {

--- a/crates/bevy-inspector-egui/src/lib.rs
+++ b/crates/bevy-inspector-egui/src/lib.rs
@@ -111,7 +111,7 @@
 //!             });
 //!
 //!             ui.heading("Entities");
-//!             bevy_inspector::ui_for_world_entities(world, ui);
+//!             bevy_inspector::ui_for_entities(world, ui);
 //!         });
 //!     });
 //! }

--- a/crates/bevy-inspector-egui/src/quick.rs
+++ b/crates/bevy-inspector-egui/src/quick.rs
@@ -485,7 +485,7 @@ fn entity_query_ui<F: QueryFilter>(world: &mut World) {
         .default_size(DEFAULT_SIZE)
         .show(egui_context.get_mut(), |ui| {
             egui::ScrollArea::both().show(ui, |ui| {
-                bevy_inspector::ui_for_world_entities_filtered_from_ui::<F>(world, ui, false);
+                bevy_inspector::ui_for_entities_filtered_with_default_filter::<F>(world, ui, false);
                 ui.allocate_space(ui.available_size());
             });
         });

--- a/crates/bevy-inspector-egui/src/quick.rs
+++ b/crates/bevy-inspector-egui/src/quick.rs
@@ -8,7 +8,7 @@
 
 use std::{marker::PhantomData, sync::Mutex};
 
-use crate::utils::pretty_type_name;
+use crate::{bevy_inspector::Filter, utils::pretty_type_name};
 use bevy_app::{App, MainScheduleOrder, Plugin, Update};
 use bevy_asset::Asset;
 use bevy_core::TypeRegistrationPlugin;
@@ -485,7 +485,7 @@ fn entity_query_ui<F: QueryFilter>(world: &mut World) {
         .default_size(DEFAULT_SIZE)
         .show(egui_context.get_mut(), |ui| {
             egui::ScrollArea::both().show(ui, |ui| {
-                bevy_inspector::ui_for_entities_filtered_with_default_filter::<F>(world, ui, false);
+                bevy_inspector::ui_for_entities_filtered(world, ui, false, &Filter::<F>::all());
                 ui.allocate_space(ui.available_size());
             });
         });

--- a/crates/bevy-inspector-egui/src/quick.rs
+++ b/crates/bevy-inspector-egui/src/quick.rs
@@ -485,7 +485,7 @@ fn entity_query_ui<F: QueryFilter>(world: &mut World) {
         .default_size(DEFAULT_SIZE)
         .show(egui_context.get_mut(), |ui| {
             egui::ScrollArea::both().show(ui, |ui| {
-                bevy_inspector::ui_for_world_entities_filtered::<F>(world, ui, false);
+                bevy_inspector::ui_for_world_entities_filtered_from_ui::<F>(world, ui, false);
                 ui.allocate_space(ui.available_size());
             });
         });


### PR DESCRIPTION
- Closes https://github.com/jakobhellermann/bevy-inspector-egui/issues/218

![image](https://github.com/user-attachments/assets/c4096743-c849-459d-8e6d-0eef2289f68c)

- Adds the ability for users to pass along their own filtering requirements.

```rust
pub trait EntityFilter {
    /// Returns true if the filter term is currently empty
    ///
    /// default impl is false
    fn is_empty(&self) -> bool {
        false
    }
    /// Returns [`Vec<Entity>`]
    fn filtered_entities(
        &self,
        world: &mut World,
        entities: impl IntoIterator<Item = Entity>,
    ) -> Vec<Entity>;
}
```

- Deprecates `ui_for_world_entities_filtered` and adds `ui_for_world_entities_filtered_from_ui` and `ui_for_world_entities_with_filter`

I tried to prioritize keeping it simple to reduce any burden supporting it introduces. I might have gotten slightly carried away. But, not having to duplicate several files worth of functions and structs to add in the desired behavior would be a nice QOL.

I believe it's backwards compatible / non-breaking but having a second pair of eyes confirm that would be nice.

---

With the ability to pass custom Filters we can now do this:

![image](https://github.com/user-attachments/assets/21787c26-0c5c-4228-ab51-46a18df4dcaf)


```rust
struct NoObserverFilter {
    filter: Filter,
    show_observers: bool,
}

impl NoObserverFilter {
    fn from_ui(ui: &mut egui::Ui) -> Self {
        let filter = Filter::from_ui(ui, FilterFromUiId::default());
        let show_observers = {
            let id = egui::Id::new("no_observer_filter_show_observers_id");
            let mut show_observers = ui.memory_mut(|mem| {
                let show_observers: &mut bool = mem.data.get_persisted_mut_or_default(id);
                *show_observers
            });
            ui.checkbox(&mut show_observers, "Show Observers");
            ui.memory_mut(|mem| {
                *mem.data.get_persisted_mut_or_default(id) = show_observers;
            });
            show_observers
        };
        Self {
            filter,
            show_observers,
        }
    }
}

impl EntityFilter for NoObserverFilter {
    const EMPTY_IS_NOOP: bool = false;

    fn is_empty(&self) -> bool {
        self.filter.is_empty()
    }

    fn filter_entity(&self, world: &mut World, entity: Entity) -> bool {
        fn is_observer(name: &str) -> bool {
            let name = name.to_lowercase();
            name.starts_with("observer ")
        }
        self.filter.filter_entity(world, entity) && {
            let name = guess_entity_name(world, entity);
            let is_observer = is_observer(&name);
            let hide_observers = !self.show_observers;
            if is_observer {
                if hide_observers && !self.filter.word.to_lowercase().starts_with("observer") {
                    return false;
                }
            }
            true
        }
    }
}

fn hierarchy_ui_with_filter(
    world: &mut World,
    ui: &mut egui::Ui,
    selected: &mut SelectedEntities,
    filter: impl EntityFilter,
) -> bool {
    let type_registry = world.resource::<AppTypeRegistry>().clone();
    let type_registry = type_registry.read();

    Hierarchy {
        world,
        type_registry: &type_registry,
        selected,
        context_menu: None,
        shortcircuit_entity: None,
        extra_state: &mut (),
    }
    .show_with_filter::<Without<Parent>, _>(ui, filter)
}

// ...
impl egui_dock::TabViewer for TabViewer<'_> {
    type Tab = EguiWindow;
    fn ui(&mut self, ui: &mut egui_dock::egui::Ui, window: &mut Self::Tab) {
      // ..
      match window {
        EguiWindow::Hierarchy => {
            let filter = NoObserverFilter::from_ui(ui);
            let selected =
                hierarchy_ui_with_filter(self.world, ui, self.selected_entities, filter);
            if selected {
                *self.selection = InspectorSelection::Entities;
            }
        }
        // ..
      }
      // ..
    }
    // ..
}
```