### PR TITLE
Update to egui 0.30, bevy_egui 0.32

### DIFF
--- a/crates/bevy-inspector-egui/Cargo.toml
+++ b/crates/bevy-inspector-egui/Cargo.toml
@@ -48,8 +48,8 @@ bevy_core_pipeline = { version = "0.15.0", optional = true }
 bevy_pbr = { version = "0.15.0", optional = true }
 bevy_image = { version = "0.15.0", optional = true }
 
-egui = "0.29"
-bevy_egui = { version = "0.31", default-features = false }
+egui = "0.30"
+bevy_egui = { version = "0.32", default-features = false }
 
 bytemuck = "1.16.0"
 image = { version = "0.25", default-features = false }
@@ -72,7 +72,7 @@ bevy = { version = "0.15.0", default-features = false, features = [
     "tonemapping_luts",
     "ktx2",
 ] }
-egui_dock = "0.14"
+egui_dock = "0.15"
 # transform-gizmo-egui = "0.1"
 # bevy_mod_picking = { git = "https://github.com/aevyrie/bevy_mod_picking", rev = "554649a951689dce66d0d759839b326874e8826f", default-features = false, features = ["backend_raycast", "backend_egui", "backend_sprite"] }
 # bevy_framepace = "0.11"

--- a/crates/bevy-inspector-egui/examples/integrations/egui_dock.rs
+++ b/crates/bevy-inspector-egui/examples/integrations/egui_dock.rs
@@ -1,6 +1,6 @@
 use bevy::prelude::*;
 use bevy_asset::{ReflectAsset, UntypedAssetId};
-use bevy_egui::EguiContext;
+use bevy_egui::{EguiContext, EguiContextSettings, EguiPostUpdateSet};
 use bevy_inspector_egui::bevy_inspector::hierarchy::{hierarchy_ui, SelectedEntities};
 use bevy_inspector_egui::bevy_inspector::{
     self, ui_for_entities_shared_components, ui_for_entity_with_children,
@@ -9,7 +9,6 @@ use bevy_inspector_egui::DefaultInspectorConfigPlugin;
 use std::any::TypeId;
 // use bevy_mod_picking::backends::egui::EguiPointer;
 // use bevy_mod_picking::prelude::*;
-use bevy_egui::EguiSet;
 use bevy_reflect::TypeRegistry;
 use bevy_render::camera::{CameraProjection, Viewport};
 use bevy_window::{PrimaryWindow, Window};
@@ -35,8 +34,8 @@ fn main() {
         .add_systems(
             PostUpdate,
             show_ui_system
-                .before(EguiSet::ProcessOutput)
-                .before(bevy_egui::systems::end_pass_system)
+                .before(EguiPostUpdateSet::ProcessOutput)
+                .before(bevy_egui::end_pass_system)
                 .before(bevy::transform::TransformSystem::TransformPropagate),
         )
         .add_systems(PostUpdate, set_camera_viewport.after(show_ui_system))
@@ -104,7 +103,7 @@ fn show_ui_system(world: &mut World) {
 fn set_camera_viewport(
     ui_state: Res<UiState>,
     primary_window: Query<&mut Window, With<PrimaryWindow>>,
-    egui_settings: Query<&bevy_egui::EguiSettings>,
+    egui_settings: Query<&EguiContextSettings>,
     mut cameras: Query<&mut Camera, With<MainCamera>>,
 ) {
     let mut cam = cameras.single_mut();

--- a/crates/bevy-inspector-egui/examples/quick/state_inspector.rs
+++ b/crates/bevy-inspector-egui/examples/quick/state_inspector.rs
@@ -12,7 +12,6 @@ fn main() {
         .init_state::<AppState>()
         .register_type::<AppState>()
         .add_plugins(StateInspectorPlugin::<AppState>::default())
-        .add_systems(Startup, setup)
         .add_systems(OnEnter(AppState::A), set_color::<158, 228, 147>)
         .add_systems(OnEnter(AppState::B), set_color::<172, 200, 192>)
         .add_systems(OnEnter(AppState::C), set_color::<194, 148, 138>)
@@ -30,20 +29,23 @@ enum AppState {
 #[derive(Component)]
 struct TheSquare;
 
-fn setup(mut commands: Commands) {
-    commands.spawn(Camera2d::default());
-
-    commands.spawn((
-        Sprite {
-            custom_size: Some(Vec2::splat(100.)),
-            ..default()
-        },
-        TheSquare,
-    ));
-}
-
 fn set_color<const R: u8, const G: u8, const B: u8>(
     mut sprite: Query<&mut Sprite, With<TheSquare>>,
+    mut commands: Commands,
 ) {
-    sprite.single_mut().color = Color::srgb_u8(R, G, B);
+    let color = Color::srgb_u8(R, G, B);
+    if let Ok(mut sprite) = sprite.get_single_mut() {
+        sprite.color = color;
+    } else {
+        commands.spawn(Camera2d);
+
+        commands.spawn((
+            Sprite {
+                custom_size: Some(Vec2::splat(100.)),
+                color,
+                ..default()
+            },
+            TheSquare,
+        ));
+    }
 }


### PR DESCRIPTION
Also fixes the state_inspector example which must have been broken since bevy 0.14, due to state scheduling changes (https://bevyengine.org/learn/migration-guides/0-13-to-0-14/#onenter-state-schedules-now-run-before-startup-schedules)