### PR TITLE
Changed so that the values of the sRGBA colors match the values in th…

### DIFF
--- a/crates/bevy-inspector-egui/examples/quick/world_inspector.rs
+++ b/crates/bevy-inspector-egui/examples/quick/world_inspector.rs
@@ -27,7 +27,7 @@ fn setup(
     commands.spawn((
         Name::new("My Cube"),
         Mesh3d(meshes.add(Cuboid::new(1.0, 1.0, 1.0))),
-        MeshMaterial3d(materials.add(Color::srgb(0.8, 0.7, 0.6))),
+        MeshMaterial3d(materials.add(Color::srgba(255. / 255., 181. / 255., 0., 102. / 255.))),
         Transform::from_xyz(0.0, 0.5, 0.0),
     ));
     // light

--- a/crates/bevy-inspector-egui/src/inspector_egui_impls/bevy_impls.rs
+++ b/crates/bevy-inspector-egui/src/inspector_egui_impls/bevy_impls.rs
@@ -200,14 +200,14 @@ impl InspectorPrimitive for Color {
                 blue,
                 alpha,
             }) => {
-                let mut color = Color32::from_rgba_premultiplied(
+                let mut color = Color32::from_rgba_unmultiplied(
                     (*red * 255.) as u8,
                     (*green * 255.) as u8,
                     (*blue * 255.) as u8,
                     (*alpha * 255.) as u8,
                 );
                 if ui.color_edit_button_srgba(&mut color).changed() {
-                    let [r, g, b, a] = color.to_array();
+                    let [r, g, b, a] = color.to_srgba_unmultiplied();
                     *red = r as f32 / 255.;
                     *green = g as f32 / 255.;
                     *blue = b as f32 / 255.;


### PR DESCRIPTION
I noticed that the values in the `sRGBA` color picker did not match up with the values I entered through code when I had an alpha value less than 1. To fix this I changed the implementation for `Color::Srgba` to covert iself to an `Color32` using `from_rgba_unmultiplied` instead of `from_rgba_premultiplied`

In the `world_inspector` example I changed the color of the cube to
```rust
Color::srgba(255. / 255., 181. / 255., 0., 102. / 255.)
```

The first image befow is before the fix, the second is after the fix

![Before](https://github.com/user-attachments/assets/4b743d01-697f-4db0-a703-fb1831e5f065)
![After](https://github.com/user-attachments/assets/e28977e6-55b2-4f83-b54e-f0ffadea404a)
