### PR TITLE
add egui_serde feature flag

### DIFF
--- a/crates/bevy-inspector-egui/Cargo.toml
+++ b/crates/bevy-inspector-egui/Cargo.toml
@@ -27,6 +27,7 @@ documentation = ["bevy_reflect/documentation"]
 bevy_render = ["dep:bevy_render", "dep:bevy_core_pipeline", "bevy_egui/render"]
 egui_clipboard = ["bevy_egui/manage_clipboard"]
 egui_open_url = ["bevy_egui/open_url"]
+egui_serde = ["bevy_egui/serde"]
 highlight_changes = []
 
 [package.metadata.docs.rs]


### PR DESCRIPTION

Adds `egui_serde` flag that solely enables the `bevy_egui/serde` flag.

I want to serialize some `egui` structs and it'd be handy to enable `serde` in `egui` without having to explicitly add `bevy_egui` to my dependencies :)