### PR TITLE
Docs and labels for types without fields

### DIFF
--- a/crates/bevy-inspector-egui/src/bevy_inspector/mod.rs
+++ b/crates/bevy-inspector-egui/src/bevy_inspector/mod.rs
@@ -592,15 +592,19 @@ pub(crate) fn ui_for_entity_components(
             continue;
         };
 
-        if size == 0 {
-            header.show(ui, |_| {});
-            continue;
-        }
-
         #[cfg(feature = "documentation")]
         let type_docs = type_registry
             .get_type_info(component_type_id)
             .and_then(|info| info.docs());
+
+        if size == 0 {
+            ui.indent(id, |ui| {
+                let _response = ui.label(&name).into();
+                #[cfg(feature = "documentation")]
+                crate::egui_utils::show_docs(_response, type_docs);
+            });
+            continue;
+        }
 
         // create a context with access to the world except for the currently viewed component
         let (mut component_view, world) = world.split_off_component((entity, component_type_id));
@@ -617,7 +621,10 @@ pub(crate) fn ui_for_entity_components(
         ) {
             Ok(value) => value,
             Err(e) => {
-                header.show(ui, |ui| errors::show_error(e, ui, &name));
+                ui.indent(id, |ui| {
+                    let response = ui.label(egui::RichText::new(&name).underline());
+                    response.on_hover_ui(|ui| errors::show_error(e, ui, &name));
+                });
                 continue;
             }
         };

--- a/crates/bevy-inspector-egui/src/egui_utils.rs
+++ b/crates/bevy-inspector-egui/src/egui_utils.rs
@@ -109,9 +109,13 @@ pub fn show_docs(response: egui::Response, docs: Option<&str>) {
             }
         }
 
-        response.on_hover_ui(|ui| {
-            easymark(ui, &docs[..end_idx]);
-        });
+        response
+            .on_hover_ui(|ui| {
+                easymark(ui, &docs[..end_idx]);
+            })
+            .on_disabled_hover_ui(|ui| {
+                easymark(ui, &docs[..end_idx]);
+            });
     }
 }
 

--- a/crates/bevy-inspector-egui/src/egui_utils.rs
+++ b/crates/bevy-inspector-egui/src/egui_utils.rs
@@ -109,13 +109,9 @@ pub fn show_docs(response: egui::Response, docs: Option<&str>) {
             }
         }
 
-        response
-            .on_hover_ui(|ui| {
-                easymark(ui, &docs[..end_idx]);
-            })
-            .on_disabled_hover_ui(|ui| {
-                easymark(ui, &docs[..end_idx]);
-            });
+        response.on_hover_ui(|ui| {
+            easymark(ui, &docs[..end_idx]);
+        });
     }
 }
 


### PR DESCRIPTION
Show docs and use label instead of CollapsingHeader for types without fields or with error.