### PR TITLE
add bevy_core_pipeline feature

### DIFF
--- a/crates/bevy-inspector-egui/Cargo.toml
+++ b/crates/bevy-inspector-egui/Cargo.toml
@@ -21,10 +21,12 @@ default = [
     "bevy_pbr",
     "bevy_image",
     "bevy_render",
+    "bevy_core_pipeline",
     "egui_clipboard",
 ]
 documentation = ["bevy_reflect/documentation"]
-bevy_render = ["dep:bevy_render", "dep:bevy_core_pipeline", "bevy_egui/render"]
+bevy_render = ["dep:bevy_render",  "bevy_egui/render"]
+bevy_core_pipeline = ["dep:bevy_core_pipeline"]
 egui_clipboard = ["bevy_egui/manage_clipboard"]
 egui_open_url = ["bevy_egui/open_url"]
 highlight_changes = []

--- a/crates/bevy-inspector-egui/src/inspector_options/default_options.rs
+++ b/crates/bevy-inspector-egui/src/inspector_options/default_options.rs
@@ -232,7 +232,7 @@ pub fn register_default_options(type_registry: &mut TypeRegistry) {
     }
 
     #[rustfmt::skip]
-    #[cfg(feature = "bevy_render")]
+    #[cfg(feature = "bevy_core_pipeline")]
     insert_options_enum::<bevy_core_pipeline::core_3d::Camera3dDepthLoadOp>(
         type_registry,
         &[


### PR DESCRIPTION
Puts `bevy_core_pipeline` behind a feature flag so that you don't have to pull in the crate if you otherwise aren't using it, fixes #240 