### PR TITLE
chore(deps): Update bevy_egui to 0.33 and egui to 0.31

### DIFF
--- a/crates/bevy-inspector-egui/Cargo.toml
+++ b/crates/bevy-inspector-egui/Cargo.toml
@@ -55,8 +55,8 @@ bevy_core_pipeline = { version = "0.15.0", optional = true }
 bevy_pbr = { version = "0.15.0", optional = true }
 bevy_image = { version = "0.15.0", optional = true }
 
-egui = "0.30"
-bevy_egui = { version = "0.32", default-features = false }
+egui = "0.31"
+bevy_egui = { version = "0.33", default-features = false }
 
 bytemuck = "1.16.0"
 image = { version = "0.25", default-features = false }


### PR DESCRIPTION
This PR simply bump the bevy_egui dependency.
- Update bevy_egui dependency from 0.32 to 0.33
- Update egui dependency from 0.30 to 0.31