### PR TITLE
Allow some color grading controls to use negative numbers

### DIFF
--- a/crates/bevy-inspector-egui/src/inspector_options/default_options.rs
+++ b/crates/bevy-inspector-egui/src/inspector_options/default_options.rs
@@ -165,7 +165,7 @@ pub fn register_default_options(type_registry: &mut TypeRegistry) {
                 ("contrast", &NumberOptions::<f32>::positive().with_speed(0.01)),
                 ("gamma", &NumberOptions::<f32>::positive().with_speed(0.01)),
                 ("gain", &NumberOptions::<f32>::positive().with_speed(0.01)),
-                ("lift", &NumberOptions::<f32>::positive().with_speed(0.01)),
+                ("lift", &NumberOptions::<f32>::default().with_speed(0.01)),
             ],
         );
 
@@ -173,9 +173,9 @@ pub fn register_default_options(type_registry: &mut TypeRegistry) {
         insert_options_struct::<bevy_render::view::ColorGradingGlobal>(
             type_registry,
             &[
-                ("exposure", &NumberOptions::<f32>::positive().with_speed(0.01)),
-                ("temperature", &NumberOptions::<f32>::positive().with_speed(0.01)),
-                ("tint", &NumberOptions::<f32>::positive().with_speed(0.01)),
+                ("exposure", &NumberOptions::<f32>::default().with_speed(0.01)),
+                ("temperature", &NumberOptions::<f32>::default().with_speed(0.01)),
+                ("tint", &NumberOptions::<f32>::default().with_speed(0.01)),
                 ("hue", &NumberOptions::<f32>::positive().with_speed(0.01)),
                 ("post_saturation", &NumberOptions::<f32>::positive().with_speed(0.01)),
                 ("midtones_range", &NumberOptions::<f32>::positive().with_speed(0.01)),


### PR DESCRIPTION
These controls are intended to be able to be set as negative numbers so they have been changed to have their minimum range removed.

* exposure
* temperature
* tint
* lift