### PR TITLE
add relationship_ui

### DIFF
--- a/crates/bevy-inspector-egui/Cargo.toml
+++ b/crates/bevy-inspector-egui/Cargo.toml
@@ -25,7 +25,7 @@ default = [
     "egui_clipboard",
 ]
 documentation = ["bevy_reflect/documentation"]
-bevy_render = ["dep:bevy_render",  "bevy_egui/render"]
+bevy_render = ["dep:bevy_render", "bevy_egui/render"]
 bevy_core_pipeline = ["dep:bevy_core_pipeline"]
 egui_clipboard = ["bevy_egui/manage_clipboard"]
 egui_open_url = ["bevy_egui/open_url"]
@@ -105,6 +105,10 @@ path = "examples/basic/custom_type_ui.rs"
 [[example]]
 name = "resource_inspector_manual"
 path = "examples/basic/resource_inspector_manual.rs"
+
+[[example]]
+name = "relationship_ui"
+path = "examples/basic/relationship_ui.rs"
 
 [[example]]
 name = "resource_inspector"

--- a/crates/bevy-inspector-egui/examples/README.md
+++ b/crates/bevy-inspector-egui/examples/README.md
@@ -3,6 +3,7 @@
 - `basic` - Basic features of the crate
   - [`inspector_options.rs`](./basic/inspector_options.rs) Shows how to use `InspectorOptions` derive to tweak the UI
   - [`resource_inspector_manual.rs`](./basic/resource_inspector_manual.rs) Shows how to customize and build your own inspector windows
+  - [`relationship_ui.rs`](./basic/relationship_ui.rs) Shows the entity ui along a specific relationship.
 - `quick` - Demonstrations of the quick plugins
   - [`world_inspector.rs`](./quick/world_inspector.rs) Example of the `WorldInspectorPlugin`
   - [`resource_inspector.rs`](./quick/resource_inspector.rs) Example of the `ResourceInspectorPlugin`

--- a/crates/bevy-inspector-egui/examples/basic/relationship_ui.rs
+++ b/crates/bevy-inspector-egui/examples/basic/relationship_ui.rs
@@ -1,0 +1,143 @@
+use bevy::prelude::*;
+use bevy_egui::{EguiContext, EguiContextPass, EguiPlugin};
+use bevy_inspector_egui::DefaultInspectorConfigPlugin;
+use bevy_window::PrimaryWindow;
+use egui::{Align2, Vec2};
+
+#[derive(Component, Debug, Reflect)]
+#[relationship(relationship_target = Container)]
+struct ContainedIn(Entity);
+
+#[derive(Component, Debug, Reflect)]
+#[relationship_target(relationship = ContainedIn)]
+struct Container(Vec<Entity>);
+
+fn main() {
+    App::new()
+        .register_type::<ContainedIn>()
+        .register_type::<Container>()
+        .add_plugins(DefaultPlugins)
+        .add_plugins(EguiPlugin {
+            enable_multipass_for_primary_context: true,
+        })
+        .add_plugins(DefaultInspectorConfigPlugin)
+        .add_systems(Startup, setup)
+        .add_systems(EguiContextPass, show_ui_system)
+        .run();
+}
+
+fn show_ui_system(world: &mut World) {
+    let Ok(egui_context) = world
+        .query_filtered::<&mut EguiContext, With<PrimaryWindow>>()
+        .single(world)
+    else {
+        return;
+    };
+    let mut egui_context: EguiContext = egui_context.clone();
+
+    egui::Window::new("Entities in Children hierarchy")
+        .anchor(Align2::LEFT_TOP, Vec2::new(10., 10.))
+        .show(egui_context.get_mut(), |ui| {
+            egui::ScrollArea::both().show(ui, |ui| {
+                bevy_inspector_egui::bevy_inspector::ui_for_entities_with_relationship::<Children>(
+                    world, ui, false,
+                );
+            });
+        });
+
+    egui::Window::new("Container hierarchy entities only")
+        .anchor(Align2::CENTER_TOP, Vec2::new(0., 10.))
+        .show(egui_context.get_mut(), |ui| {
+            egui::ScrollArea::both().show(ui, |ui| {
+                bevy_inspector_egui::bevy_inspector::ui_for_entities_with_relationship::<Container>(
+                    world, ui, true,
+                );
+            });
+        });
+
+    egui::Window::new("All entities in Container hierarchy")
+        .anchor(Align2::RIGHT_TOP, Vec2::new(-10., 10.))
+        .show(egui_context.get_mut(), |ui| {
+            egui::ScrollArea::both().show(ui, |ui| {
+                bevy_inspector_egui::bevy_inspector::ui_for_entities_with_relationship::<Container>(
+                    world, ui, false,
+                );
+            });
+        });
+}
+
+/// set up a simple 3D scene
+fn setup(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+) {
+    // plane
+    commands.spawn((
+        Mesh3d(meshes.add(Plane3d::default().mesh().size(5.0, 5.0))),
+        MeshMaterial3d(materials.add(Color::srgb(0.3, 0.5, 0.3))),
+    ));
+    // cube
+    let cube = commands
+        .spawn((
+            Name::new("My Cube"),
+            Mesh3d(meshes.add(Cuboid::new(1.0, 1.0, 1.0))),
+            MeshMaterial3d(materials.add(Color::srgba(255., 181. / 255., 0., 102. / 255.))),
+            Transform::from_xyz(0.0, 0.5, 0.0),
+            children![(
+                Name::new("Cube Nose"),
+                Mesh3d(meshes.add(Cuboid::new(0.1, 0.1, 0.1))),
+                MeshMaterial3d(materials.add(Color::srgba(55., 51. / 255., 0., 52. / 255.))),
+                Transform::from_xyz(-0.5, 0.0, 0.0),
+            )],
+        ))
+        .id();
+
+    // sword
+    commands.spawn((
+        Name::new("Sword"),
+        Mesh3d(meshes.add(Cuboid::new(0.85, 0.05, 0.05))),
+        MeshMaterial3d(materials.add(Color::srgba(
+            20. / 255.,
+            20. / 255.,
+            20. / 255.,
+            200. / 255.,
+        ))),
+        Transform::from_xyz(-0.3, 0.5, -0.2),
+        ContainedIn(cube),
+    ));
+
+    // shield
+    let shield = commands
+        .spawn((
+            Name::new("Shield"),
+            Mesh3d(meshes.add(Cuboid::new(0.85, 0.8, 0.05))),
+            MeshMaterial3d(materials.add(Color::srgba(
+                20. / 255.,
+                20. / 255.,
+                20. / 255.,
+                200. / 255.,
+            ))),
+            Transform::from_xyz(0.0, 0.5, 0.7),
+            ContainedIn(cube),
+        ))
+        .id();
+
+    // hidden letter
+    commands.spawn((Name::new("Hidden Letter"), ContainedIn(shield)));
+
+    // light
+    commands.spawn((
+        PointLight {
+            intensity: 2_000_000.0,
+            shadows_enabled: true,
+            ..default()
+        },
+        Transform::from_xyz(4.0, 8.0, 4.0),
+    ));
+    // camera
+    commands.spawn((
+        Camera3d::default(),
+        Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
+    ));
+}

--- a/crates/bevy-inspector-egui/src/quick.rs
+++ b/crates/bevy-inspector-egui/src/quick.rs
@@ -17,7 +17,7 @@ use bevy_reflect::Reflect;
 use bevy_state::state::FreelyMutableState;
 use bevy_window::PrimaryWindow;
 
-use crate::{bevy_inspector, DefaultInspectorConfigPlugin};
+use crate::{DefaultInspectorConfigPlugin, bevy_inspector};
 
 const DEFAULT_SIZE: (f32, f32) = (320., 160.);
 
@@ -452,7 +452,13 @@ fn entity_query_ui<F: QueryFilter>(world: &mut World) {
         .default_size(DEFAULT_SIZE)
         .show(egui_context.get_mut(), |ui| {
             egui::ScrollArea::both().show(ui, |ui| {
-                bevy_inspector::ui_for_entities_filtered(world, ui, false, &Filter::<F>::all());
+                bevy_inspector::ui_for_entities_filtered(
+                    world,
+                    ui,
+                    false,
+                    false,
+                    &Filter::<F>::all(),
+                );
                 ui.allocate_space(ui.available_size());
             });
         });


### PR DESCRIPTION
Hey, just had an idea that the entity hierarchy tree could be generic along relationships instead of just Children now that 0.16 landed. I just scribbled down this implementation, and haven't touched the comments.

Feel free to close if not interested, I can just move the implementation out for myself! :)