### PR TITLE
Clean up example imports

### DIFF
--- a/crates/bevy-inspector-egui/examples/basic/custom_type_ui.rs
+++ b/crates/bevy-inspector-egui/examples/basic/custom_type_ui.rs
@@ -1,8 +1,10 @@
 use bevy::prelude::*;
-use bevy_inspector_egui::bevy_egui::EguiPlugin;
-use bevy_inspector_egui::inspector_egui_impls::{InspectorEguiImpl, InspectorPrimitive};
-use bevy_inspector_egui::quick::ResourceInspectorPlugin;
-use bevy_inspector_egui::reflect_inspector::InspectorUi;
+use bevy_inspector_egui::{
+    bevy_egui::EguiPlugin,
+    inspector_egui_impls::{InspectorEguiImpl, InspectorPrimitive},
+    quick::ResourceInspectorPlugin,
+    reflect_inspector::InspectorUi,
+};
 
 #[derive(Resource, Reflect, Default)]
 struct Config {

--- a/crates/bevy-inspector-egui/examples/basic/inspector_options.rs
+++ b/crates/bevy-inspector-egui/examples/basic/inspector_options.rs
@@ -1,9 +1,8 @@
-use bevy::prelude::*;
-use bevy_egui::EguiContext;
-use bevy_inspector_egui::inspector_options::std_options::NumberDisplay;
-use bevy_inspector_egui::{prelude::*, DefaultInspectorConfigPlugin};
-use bevy_platform::collections::HashMap;
-use bevy_window::PrimaryWindow;
+use bevy::{platform::collections::HashMap, prelude::*, window::PrimaryWindow};
+use bevy_inspector_egui::{
+    DefaultInspectorConfigPlugin, bevy_egui::EguiContext,
+    inspector_options::std_options::NumberDisplay, prelude::*,
+};
 
 #[derive(Reflect, InspectorOptions)]
 #[reflect(InspectorOptions)]

--- a/crates/bevy-inspector-egui/examples/basic/resource_inspector_manual.rs
+++ b/crates/bevy-inspector-egui/examples/basic/resource_inspector_manual.rs
@@ -1,8 +1,9 @@
-use bevy::prelude::*;
-use bevy_inspector_egui::bevy_egui::{EguiContext, EguiContextPass, EguiPlugin};
-use bevy_inspector_egui::prelude::*;
-use bevy_inspector_egui::DefaultInspectorConfigPlugin;
-use bevy_window::PrimaryWindow;
+use bevy::{prelude::*, window::PrimaryWindow};
+use bevy_inspector_egui::{
+    DefaultInspectorConfigPlugin,
+    bevy_egui::{EguiContext, EguiContextPass, EguiPlugin},
+    prelude::*,
+};
 
 #[derive(Reflect, Resource, Default, InspectorOptions)]
 #[reflect(Resource, InspectorOptions)]

--- a/crates/bevy-inspector-egui/examples/integrations/egui_dock.rs
+++ b/crates/bevy-inspector-egui/examples/integrations/egui_dock.rs
@@ -1,20 +1,24 @@
-use bevy::prelude::*;
-use bevy_asset::{ReflectAsset, UntypedAssetId};
-use bevy_egui::{EguiContext, EguiContextPass, EguiContextSettings};
-use bevy_inspector_egui::bevy_inspector::hierarchy::{hierarchy_ui, SelectedEntities};
-use bevy_inspector_egui::bevy_inspector::{
-    self, ui_for_entities_shared_components, ui_for_entity_with_children,
-};
-use bevy_inspector_egui::DefaultInspectorConfigPlugin;
-use bevy_math::{DQuat, DVec3};
 use std::any::TypeId;
-// use bevy_mod_picking::backends::egui::EguiPointer;
-// use bevy_mod_picking::prelude::*;
-use bevy_reflect::TypeRegistry;
-use bevy_render::camera::{CameraProjection, Viewport};
-use bevy_window::{PrimaryWindow, Window};
-use egui_dock::{DockArea, DockState, NodeIndex, Style};
 
+use bevy::{
+    asset::{ReflectAsset, UntypedAssetId},
+    math::{DQuat, DVec3},
+    prelude::*,
+    reflect::TypeRegistry,
+    render::camera::{CameraProjection, Viewport},
+    window::{PrimaryWindow, Window},
+};
+use bevy_inspector_egui::{
+    DefaultInspectorConfigPlugin,
+    bevy_egui::{EguiContext, EguiContextPass, EguiContextSettings},
+    bevy_inspector::{
+        self,
+        hierarchy::{SelectedEntities, hierarchy_ui},
+        ui_for_entities_shared_components, ui_for_entity_with_children,
+    },
+};
+
+use egui_dock::{DockArea, DockState, NodeIndex, Style};
 use transform_gizmo_egui::{Gizmo, GizmoConfig, GizmoExt, GizmoOrientation};
 
 fn main() {

--- a/crates/bevy-inspector-egui/examples/integrations/side_panel.rs
+++ b/crates/bevy-inspector-egui/examples/integrations/side_panel.rs
@@ -1,12 +1,11 @@
 use std::ops::DerefMut;
 
-use bevy::{input::common_conditions::input_toggle_active, prelude::*};
+use bevy::{input::common_conditions::input_toggle_active, prelude::*, window::PrimaryWindow};
 use bevy_inspector_egui::{
+    DefaultInspectorConfigPlugin,
     bevy_egui::{EguiContext, EguiContextPass, EguiPlugin},
     bevy_inspector::hierarchy::SelectedEntities,
-    DefaultInspectorConfigPlugin,
 };
-use bevy_window::PrimaryWindow;
 
 fn main() {
     App::new()

--- a/crates/bevy-inspector-egui/examples/quick/resource_inspector.rs
+++ b/crates/bevy-inspector-egui/examples/quick/resource_inspector.rs
@@ -1,9 +1,7 @@
-use bevy::input::common_conditions::input_toggle_active;
-use bevy::prelude::*;
-
-use bevy_inspector_egui::quick::ResourceInspectorPlugin;
-use bevy_inspector_egui::{bevy_egui::EguiPlugin, prelude::*};
-use bevy_platform::collections::HashSet;
+use bevy::{
+    input::common_conditions::input_toggle_active, platform::collections::HashSet, prelude::*,
+};
+use bevy_inspector_egui::{bevy_egui::EguiPlugin, prelude::*, quick::ResourceInspectorPlugin};
 
 #[derive(Reflect, Resource, Default, InspectorOptions)]
 #[reflect(Resource, InspectorOptions)]

--- a/crates/bevy-inspector-egui/examples/quick/state_inspector.rs
+++ b/crates/bevy-inspector-egui/examples/quick/state_inspector.rs
@@ -1,9 +1,11 @@
-use bevy::prelude::*;
-use bevy_inspector_egui::{bevy_egui::EguiPlugin, quick::StateInspectorPlugin};
-use bevy_state::{
-    app::AppExtStates,
-    state::{OnEnter, States},
+use bevy::{
+    prelude::*,
+    state::{
+        app::AppExtStates,
+        state::{OnEnter, States},
+    },
 };
+use bevy_inspector_egui::{bevy_egui::EguiPlugin, quick::StateInspectorPlugin};
 
 fn main() {
     App::new()

--- a/crates/bevy-inspector-egui/examples/quick/world_inspector.rs
+++ b/crates/bevy-inspector-egui/examples/quick/world_inspector.rs
@@ -1,7 +1,5 @@
-use bevy::input::common_conditions::input_toggle_active;
-use bevy::prelude::*;
-use bevy_egui::EguiPlugin;
-use bevy_inspector_egui::quick::WorldInspectorPlugin;
+use bevy::{input::common_conditions::input_toggle_active, prelude::*};
+use bevy_inspector_egui::{bevy_egui::EguiPlugin, quick::WorldInspectorPlugin};
 
 fn main() {
     App::new()


### PR DESCRIPTION
## Motivation

The particular example I was looking at while migrating my code imported `EguiPlugin` from `bevy_egui`, and from this I leapt to the conclusion that I now needed at add `bevy_egui` to my own projects. That's not actually the case, because `bevy_inspector_egui` re-exports `bevy_egui`.

## Solution

- Use re-exported `bevy_egui`
- Use bevy types from `bevy` rather than individual crates -- end users don't usually depend on individual crates
- Tidying, group and order imports