### PR TITLE
Remove misleading comment

### DIFF
--- a/crates/bevy-inspector-egui/examples/basic/resource_inspector_manual.rs
+++ b/crates/bevy-inspector-egui/examples/basic/resource_inspector_manual.rs
@@ -1,7 +1,7 @@
 use bevy::prelude::*;
+use bevy_inspector_egui::DefaultInspectorConfigPlugin;
 use bevy_inspector_egui::bevy_egui::{EguiContext, EguiContextPass, EguiPlugin};
 use bevy_inspector_egui::prelude::*;
-use bevy_inspector_egui::DefaultInspectorConfigPlugin;
 use bevy_window::PrimaryWindow;
 
 #[derive(Reflect, Resource, Default, InspectorOptions)]
@@ -15,7 +15,6 @@ struct Configuration {
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        // if you don't use the `quick` plugins you need to add the `EguiPlugin` and the default inspector settings yourself
         .add_plugins(EguiPlugin {
             enable_multipass_for_primary_context: true,
         })


### PR DESCRIPTION
This comment suggests that manually adding `EguiPlugin` is optional if you use `quick` plugins.

But if I run the `quick/world_inspector` example without `EguiPlugin`, I get the following panic:

```
thread 'main' panicked at /Users/me/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/bevy-inspector-egui-0.31.0/src/quick.rs:473:9:
`WorldInspectorPlugin` needs to be added after `EguiPlugin`:
        .add_plugins(EguiPlugin { enable_multipass_for_primary_context: true })
        .add_plugins(WorldInspectorPlugin::default())
            
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

All the examples in `quick/` do this, so I am assuming that the comment is just out of date.