### PR TITLE
Upgrade from bevy_egui 0.34 to 0.35

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ use bevy_inspector_egui::quick::WorldInspectorPlugin;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugins(EguiPlugin { enable_multipass_for_primary_context: true })
+        .add_plugins(EguiPlugin::default())
         .add_plugins(WorldInspectorPlugin::new())
         .run();
 }
@@ -59,7 +59,7 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .init_resource::<Configuration>() // `ResourceInspectorPlugin` won't initialize the resource
         .register_type::<Configuration>() // you need to register your type to display it
-        .add_plugins(EguiPlugin { enable_multipass_for_primary_context: true })
+        .add_plugins(EguiPlugin::default())
         .add_plugins(ResourceInspectorPlugin::<Configuration>::default())
         // also works with built-in resources, as long as they are `Reflect`
         .add_plugins(ResourceInspectorPlugin::<Time>::default())
@@ -84,9 +84,9 @@ use std::any::TypeId;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugins(EguiPlugin { enable_multipass_for_primary_context: true })
+        .add_plugins(EguiPlugin::default())
         .add_plugins(bevy_inspector_egui::DefaultInspectorConfigPlugin) // adds default options and `InspectorEguiImpl`s
-        .add_systems(EguiContextPass, inspector_ui)
+        .add_systems(EguiPrimaryContextPass, inspector_ui)
         .run();
 }
 

--- a/crates/bevy-inspector-egui-derive/Cargo.toml
+++ b/crates/bevy-inspector-egui-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy-inspector-egui-derive"
-version = "0.31.0"
+version = "0.32.0"
 edition = "2021"
 repository = "https://github.com/jakobhellermann/bevy-inspector-egui/"
 readme = "README.md"

--- a/crates/bevy-inspector-egui/Cargo.toml
+++ b/crates/bevy-inspector-egui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy-inspector-egui"
-version = "0.31.0"
+version = "0.32.0"
 edition = "2024"
 repository = "https://github.com/jakobhellermann/bevy-inspector-egui/"
 readme = "README.md"
@@ -37,7 +37,7 @@ features = ["winit/x11"]
 [dependencies]
 winit = { version = "0.30.0", default-features = false }
 
-bevy-inspector-egui-derive = { version = "0.31.0", path = "../bevy-inspector-egui-derive" }
+bevy-inspector-egui-derive = { version = "0.32.0", path = "../bevy-inspector-egui-derive" }
 bevy_app = { version = "0.16.0" }
 bevy_asset = { version = "0.16.0" }
 bevy_color = { version = "0.16.0" }
@@ -60,7 +60,7 @@ bevy_image = { version = "0.16.0", optional = true }
 
 egui = "0.31"
 
-bevy_egui = { version = "0.34.0", default-features = false }
+bevy_egui = { version = "0.35.0", default-features = false }
 
 bytemuck = "1.16.0"
 image = { version = "0.25", default-features = false }

--- a/crates/bevy-inspector-egui/examples/basic/custom_type_ui.rs
+++ b/crates/bevy-inspector-egui/examples/basic/custom_type_ui.rs
@@ -45,9 +45,7 @@ impl InspectorPrimitive for ToggleOption {
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugins(EguiPlugin {
-            enable_multipass_for_primary_context: true,
-        })
+        .add_plugins(EguiPlugin::default())
         .add_plugins(ResourceInspectorPlugin::<Config>::new())
         .init_resource::<Config>()
         .register_type::<ToggleOption>()

--- a/crates/bevy-inspector-egui/examples/basic/inspector_options.rs
+++ b/crates/bevy-inspector-egui/examples/basic/inspector_options.rs
@@ -1,5 +1,5 @@
 use bevy::{platform::collections::HashMap, prelude::*, window::PrimaryWindow};
-use bevy_egui::EguiContextPass;
+use bevy_egui::EguiPrimaryContextPass;
 use bevy_inspector_egui::{
     DefaultInspectorConfigPlugin, bevy_egui::EguiContext,
     inspector_options::std_options::NumberDisplay, prelude::*,
@@ -69,16 +69,14 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_plugins(DefaultInspectorConfigPlugin)
-        .add_plugins(bevy_egui::EguiPlugin {
-            enable_multipass_for_primary_context: true,
-        })
+        .add_plugins(EguiPlugin::default())
         // types need to be registered
         .init_resource::<UiData>()
         .register_type::<Config>()
         .register_type::<Shape>()
         .register_type::<UiData>()
         .add_systems(Startup, setup)
-        .add_systems(EguiContextPass, ui_example)
+        .add_systems(EguiPrimaryContextPass, ui_example)
         .run();
 }
 
@@ -89,7 +87,7 @@ fn setup(mut commands: Commands, mut ui_data: ResMut<UiData>) {
 
 fn ui_example(world: &mut World) {
     let Ok(egui_context) = world
-        .query_filtered::<&mut EguiContext, With<PrimaryWindow>>()
+        .query_filtered::<&mut EguiContext, With<PrimaryEguiContext>>()
         .single(world)
     else {
         return;

--- a/crates/bevy-inspector-egui/examples/basic/resource_inspector_manual.rs
+++ b/crates/bevy-inspector-egui/examples/basic/resource_inspector_manual.rs
@@ -41,7 +41,7 @@ fn inspector_ui(world: &mut World, mut disabled: Local<bool>) {
     }
 
     let Ok(egui_context) = world
-        .query_filtered::<&mut EguiContext, With<PrimaryWindow>>()
+        .query_filtered::<&mut EguiContext, With<PrimaryEguiContext>>()
         .single(world)
     else {
         return;

--- a/crates/bevy-inspector-egui/examples/integrations/egui_dock.rs
+++ b/crates/bevy-inspector-egui/examples/integrations/egui_dock.rs
@@ -10,7 +10,7 @@ use bevy::{
 };
 use bevy_inspector_egui::{
     DefaultInspectorConfigPlugin,
-    bevy_egui::{EguiContext, EguiContextPass, EguiContextSettings},
+    bevy_egui::{EguiContext, EguiPrimaryContextPass, EguiContextSettings},
     bevy_inspector::{
         self,
         hierarchy::{SelectedEntities, hierarchy_ui},
@@ -25,14 +25,12 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         // .add_plugins(bevy_framepace::FramepacePlugin) // reduces input lag
-        .add_plugins(bevy_egui::EguiPlugin {
-            enable_multipass_for_primary_context: true,
-        })
+        .add_plugins(bevy_egui::EguiPlugin::default())
         .add_plugins(DefaultInspectorConfigPlugin)
         // .add_plugins(bevy_mod_picking::plugins::DefaultPickingPlugins)
         .insert_resource(UiState::new())
         .add_systems(Startup, setup)
-        .add_systems(EguiContextPass, show_ui_system)
+        .add_systems(EguiPrimaryContextPass, show_ui_system)
         .add_systems(PostUpdate, set_camera_viewport.after(show_ui_system))
         // .add_systems(Update, auto_add_raycast_target)
         // .add_systems(Update, handle_pick_events)
@@ -81,7 +79,7 @@ struct MainCamera;
 
 fn show_ui_system(world: &mut World) {
     let Ok(egui_context) = world
-        .query_filtered::<&mut EguiContext, With<PrimaryWindow>>()
+        .query_filtered::<&mut EguiContext, With<PrimaryEguiContext>>()
         .single(world)
     else {
         return;

--- a/crates/bevy-inspector-egui/examples/integrations/side_panel.rs
+++ b/crates/bevy-inspector-egui/examples/integrations/side_panel.rs
@@ -3,7 +3,7 @@ use std::ops::DerefMut;
 use bevy::{input::common_conditions::input_toggle_active, prelude::*, window::PrimaryWindow};
 use bevy_inspector_egui::{
     DefaultInspectorConfigPlugin,
-    bevy_egui::{EguiContext, EguiContextPass, EguiPlugin},
+    bevy_egui::{EguiContext, EguiPrimaryContextPass, EguiPlugin},
     bevy_inspector::hierarchy::SelectedEntities,
 };
 
@@ -17,7 +17,7 @@ fn main() {
         .add_systems(Startup, setup)
         .add_systems(Update, rotator_system)
         .add_systems(
-            EguiContextPass,
+            EguiPrimaryContextPass,
             inspector_ui.run_if(input_toggle_active(true, KeyCode::Escape)),
         )
         .run();

--- a/crates/bevy-inspector-egui/examples/quick/asset_inspector.rs
+++ b/crates/bevy-inspector-egui/examples/quick/asset_inspector.rs
@@ -5,9 +5,7 @@ use bevy_inspector_egui::quick::AssetInspectorPlugin;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugins(EguiPlugin {
-            enable_multipass_for_primary_context: true,
-        })
+        .add_plugins(EguiPlugin::default())
         .add_plugins(AssetInspectorPlugin::<StandardMaterial>::default())
         .add_systems(Startup, setup)
         .run();

--- a/crates/bevy-inspector-egui/examples/quick/filter_query_inspector.rs
+++ b/crates/bevy-inspector-egui/examples/quick/filter_query_inspector.rs
@@ -4,9 +4,7 @@ use bevy_inspector_egui::{bevy_egui::EguiPlugin, quick::FilterQueryInspectorPlug
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugins(EguiPlugin {
-            enable_multipass_for_primary_context: true,
-        })
+        .add_plugins(EguiPlugin::default())
         .add_plugins(FilterQueryInspectorPlugin::<With<Transform>>::default())
         .add_systems(Startup, setup)
         .run();

--- a/crates/bevy-inspector-egui/examples/quick/resource_inspector.rs
+++ b/crates/bevy-inspector-egui/examples/quick/resource_inspector.rs
@@ -15,9 +15,7 @@ struct Configuration {
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugins(EguiPlugin {
-            enable_multipass_for_primary_context: true,
-        })
+        .add_plugins(EguiPlugin::default())
         .add_plugins(
             ResourceInspectorPlugin::<Configuration>::default()
                 .run_if(input_toggle_active(true, KeyCode::Escape)),

--- a/crates/bevy-inspector-egui/examples/quick/state_inspector.rs
+++ b/crates/bevy-inspector-egui/examples/quick/state_inspector.rs
@@ -10,9 +10,7 @@ use bevy_inspector_egui::{bevy_egui::EguiPlugin, quick::StateInspectorPlugin};
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugins(EguiPlugin {
-            enable_multipass_for_primary_context: true,
-        })
+        .add_plugins(EguiPlugin::default())
         .insert_resource(ClearColor(Color::BLACK))
         .init_state::<AppState>()
         .register_type::<AppState>()

--- a/crates/bevy-inspector-egui/examples/quick/world_inspector.rs
+++ b/crates/bevy-inspector-egui/examples/quick/world_inspector.rs
@@ -4,9 +4,7 @@ use bevy_inspector_egui::{bevy_egui::EguiPlugin, quick::WorldInspectorPlugin};
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugins(EguiPlugin {
-            enable_multipass_for_primary_context: true,
-        })
+        .add_plugins(EguiPlugin::default())
         .add_plugins(
             WorldInspectorPlugin::default().run_if(input_toggle_active(true, KeyCode::Escape)),
         )

--- a/crates/bevy-inspector-egui/examples/quick/world_inspector_assets.rs
+++ b/crates/bevy-inspector-egui/examples/quick/world_inspector_assets.rs
@@ -6,9 +6,7 @@ use bevy_inspector_egui::{bevy_egui::EguiPlugin, quick::WorldInspectorPlugin};
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugins(EguiPlugin {
-            enable_multipass_for_primary_context: true,
-        })
+        .add_plugins(EguiPlugin::default())
         .add_plugins(WorldInspectorPlugin::default())
         .add_systems(Startup, setup)
         .run();

--- a/crates/bevy-inspector-egui/src/lib.rs
+++ b/crates/bevy-inspector-egui/src/lib.rs
@@ -76,7 +76,7 @@
 //!
 //! ```no_run
 //! use bevy::prelude::*;
-//! use bevy_egui::{EguiPlugin, EguiContext, EguiContextPass};
+//! use bevy_egui::{EguiPlugin, EguiContext, EguiPrimaryContextPass};
 //! use bevy_inspector_egui::prelude::*;
 //! use bevy_inspector_egui::bevy_inspector;
 //! use bevy_window::PrimaryWindow;
@@ -85,15 +85,15 @@
 //! fn main() {
 //!     App::new()
 //!         .add_plugins(DefaultPlugins)
-//!         .add_plugins(EguiPlugin { enable_multipass_for_primary_context: true })
+//!         .add_plugins(EguiPlugin::default())
 //!         .add_plugins(bevy_inspector_egui::DefaultInspectorConfigPlugin) // adds default options and `InspectorEguiImpl`s
-//!         .add_systems(EguiContextPass, inspector_ui)
+//!         .add_systems(EguiPrimaryContextPass, inspector_ui)
 //!         .run();
 //! }
 //!
 //! fn inspector_ui(world: &mut World) {
 //!     let mut egui_context = world
-//!         .query_filtered::<&mut EguiContext, With<PrimaryWindow>>()
+//!         .query_filtered::<&mut EguiContext, With<PrimaryEguiContext>>()
 //!         .single(world)
 //!         .expect("EguiContext not found")
 //!         .clone();

--- a/crates/bevy-inspector-egui/src/reflect_inspector/mod.rs
+++ b/crates/bevy-inspector-egui/src/reflect_inspector/mod.rs
@@ -59,7 +59,9 @@
 //! }
 //! ```
 
+#[cfg(feature = "documentation")]
 use crate::egui_utils::show_docs;
+
 use crate::inspector_egui_impls::{InspectorEguiImpl, iter_all_eq};
 use crate::inspector_options::{InspectorOptions, ReflectInspectorOptions, Target};
 use crate::restricted_world_view::RestrictedWorldView;


### PR DESCRIPTION
Hi,
I am a newcomer to Bevy that has tried this week to mix egui_dock and bevy-inspector-egui in a same bevy 0.16.1 pet project and I ended up with two versions of bevy_egui : 0.34.1 and 0.35.1.

I try here to make the needed changes for bevy-inspector-egui to use bevy_egui 0.35.0 on my side, hoping you can use some part of the effort for your next release.

I got a working WorldInspector and a FilterQueryInspectorPlugin for now.
I will try now to run all shipped examples from your crate to seek missing edits.

Thanks for all the birds,
Ludolpif