### PR TITLE
if let && replaced with nested if statements

### DIFF
--- a/crates/bevy-inspector-egui/src/bevy_inspector/hierarchy.rs
+++ b/crates/bevy-inspector-egui/src/bevy_inspector/hierarchy.rs
@@ -145,10 +145,10 @@ impl<T> Hierarchy<'_, T> {
             None
         };
 
-        if let Some(shortcircuit_entity) = self.shortcircuit_entity.as_mut()
-            && shortcircuit_entity(ui, entity, self.world, self.extra_state)
-        {
-            return false;
+        if let Some(shortcircuit_entity) = self.shortcircuit_entity.as_mut() {
+            if shortcircuit_entity(ui, entity, self.world, self.extra_state) {
+                return false;
+            }
         }
 
         #[allow(deprecated)] // the suggested replacement doesn't really work

--- a/crates/bevy-inspector-egui/src/bevy_inspector/mod.rs
+++ b/crates/bevy-inspector-egui/src/bevy_inspector/mod.rs
@@ -518,22 +518,29 @@ fn ui_for_entity_with_children_inner<F>(
     let children = world
         .get::<Children>(entity)
         .map(|children| children.iter().collect::<Vec<_>>());
-    if let Some(mut children) = children
-        && !children.is_empty()
-    {
-        filter.filter_entities(world, &mut children);
-        ui.label("Children");
-        for child in children {
-            let id = id.with(child);
+    if let Some(mut children) = children {
+        if !children.is_empty() {
+            filter.filter_entities(world, &mut children);
+            ui.label("Children");
+            for child in children {
+                let id = id.with(child);
 
-            let child_entity_name = guess_entity_name(world, child);
-            egui::CollapsingHeader::new(&child_entity_name)
-                .id_salt(id)
-                .show(ui, |ui| {
-                    ui.label(&child_entity_name);
+                let child_entity_name = guess_entity_name(world, child);
+                egui::CollapsingHeader::new(&child_entity_name)
+                    .id_salt(id)
+                    .show(ui, |ui| {
+                        ui.label(&child_entity_name);
 
-                    ui_for_entity_with_children_inner(world, child, ui, id, type_registry, filter);
-                });
+                        ui_for_entity_with_children_inner(
+                            world,
+                            child,
+                            ui,
+                            id,
+                            type_registry,
+                            filter,
+                        );
+                    });
+            }
         }
     }
 

--- a/crates/bevy-inspector-egui/src/egui_utils.rs
+++ b/crates/bevy-inspector-egui/src/egui_utils.rs
@@ -392,8 +392,8 @@ pub mod easymark {
 
             // ```{language}\n{code}```
             fn code_block(&mut self) -> Option<Item<'a>> {
-                if let Some(language_start) = self.s.strip_prefix("```")
-                    && let Some(newline) = language_start.find('\n')
+                if let Some(language_start) = self.s.strip_prefix("```") {
+                    if let Some(newline) = language_start.find('\n')
                 {
                     let language = &language_start[..newline];
                     let code_start = &language_start[newline + 1..];
@@ -406,7 +406,7 @@ pub mod easymark {
                         self.s = "";
                         return Some(Item::CodeBlock(language, code_start));
                     }
-                }
+                }}
                 None
             }
 

--- a/crates/bevy-inspector-egui/src/egui_utils.rs
+++ b/crates/bevy-inspector-egui/src/egui_utils.rs
@@ -393,20 +393,20 @@ pub mod easymark {
             // ```{language}\n{code}```
             fn code_block(&mut self) -> Option<Item<'a>> {
                 if let Some(language_start) = self.s.strip_prefix("```") {
-                    if let Some(newline) = language_start.find('\n')
-                {
-                    let language = &language_start[..newline];
-                    let code_start = &language_start[newline + 1..];
-                    if let Some(end) = code_start.find("\n```") {
-                        let code = &code_start[..end].trim();
-                        self.s = &code_start[end + 4..];
-                        self.start_of_line = false;
-                        return Some(Item::CodeBlock(language, code));
-                    } else {
-                        self.s = "";
-                        return Some(Item::CodeBlock(language, code_start));
+                    if let Some(newline) = language_start.find('\n') {
+                        let language = &language_start[..newline];
+                        let code_start = &language_start[newline + 1..];
+                        if let Some(end) = code_start.find("\n```") {
+                            let code = &code_start[..end].trim();
+                            self.s = &code_start[end + 4..];
+                            self.start_of_line = false;
+                            return Some(Item::CodeBlock(language, code));
+                        } else {
+                            self.s = "";
+                            return Some(Item::CodeBlock(language, code_start));
+                        }
                     }
-                }}
+                }
                 None
             }
 

--- a/crates/bevy-inspector-egui/src/inspector_egui_impls/bevy_impls.rs
+++ b/crates/bevy-inspector-egui/src/inspector_egui_impls/bevy_impls.rs
@@ -75,14 +75,15 @@ impl InspectorPrimitive for Entity {
                             id,
                             env.type_registry,
                         );
-                        if options.despawnable
-                            && world.contains_entity(entity)
-                            && let Some(queue) = queue
-                            && egui_utils::label_button(ui, "✖ Despawn", egui::Color32::RED)
-                        {
-                            queue.push(move |world: &mut World| {
-                                world.entity_mut(entity).despawn();
-                            });
+                        if let Some(queue) = queue {
+                            if options.despawnable
+                                && world.contains_entity(entity)
+                                && egui_utils::label_button(ui, "✖ Despawn", egui::Color32::RED)
+                            {
+                                queue.push(move |world: &mut World| {
+                                    world.entity_mut(entity).despawn();
+                                });
+                            }
                         }
                     });
             }

--- a/crates/bevy-inspector-egui/src/reflect_inspector/mod.rs
+++ b/crates/bevy-inspector-egui/src/reflect_inspector/mod.rs
@@ -229,22 +229,24 @@ impl InspectorUi<'_, '_> {
         options: &dyn Any,
     ) -> bool {
         let mut options = options;
-        if options.is::<()>()
-            && let Some(data) = value.try_as_reflect().and_then(|val| {
+        if options.is::<()>() {
+            if let Some(data) = value.try_as_reflect().and_then(|val| {
                 self.type_registry
                     .get_type_data::<ReflectInspectorOptions>(val.type_id())
-            })
-        {
-            options = &data.0;
+            }) {
+                options = &data.0;
+            }
         }
 
-        if let Some(reflected) = value.try_as_reflect_mut()
-            && let Some(s) = self
+        if let Some(reflected) = value.try_as_reflect_mut() {
+            if let Some(s) = self
                 .type_registry
                 .get_type_data::<InspectorEguiImpl>(reflected.reflect_type_info().type_id())
-            && let Some(value) = value.try_as_reflect_mut()
-        {
-            return s.execute(value.as_any_mut(), ui, options, id, self.reborrow());
+            {
+                if let Some(value) = value.try_as_reflect_mut() {
+                    return s.execute(value.as_any_mut(), ui, options, id, self.reborrow());
+                }
+            }
         }
 
         if let Some(changed) = (self.short_circuit)(self, value, ui, id, options) {
@@ -282,23 +284,27 @@ impl InspectorUi<'_, '_> {
         options: &dyn Any,
     ) {
         let mut options = options;
-        if options.is::<()>()
-            && let Some(value_reflect) = value.try_as_reflect()
-            && let Some(data) = self
-                .type_registry
-                .get_type_data::<ReflectInspectorOptions>(value_reflect.type_id())
-        {
-            options = &data.0;
+        if options.is::<()>() {
+            if let Some(value_reflect) = value.try_as_reflect() {
+                if let Some(data) = self
+                    .type_registry
+                    .get_type_data::<ReflectInspectorOptions>(value_reflect.type_id())
+                {
+                    options = &data.0;
+                }
+            }
         }
 
-        if let Some(value_reflect) = value.try_as_reflect()
-            && let Some(s) = self
+        if let Some(value_reflect) = value.try_as_reflect() {
+            if let Some(s) = self
                 .type_registry
                 .get_type_data::<InspectorEguiImpl>(value_reflect.type_id())
-            && let Some(value) = value.try_as_reflect()
-        {
-            s.execute_readonly(value.as_any(), ui, options, id, self.reborrow());
-            return;
+            {
+                if let Some(value) = value.try_as_reflect() {
+                    s.execute_readonly(value.as_any(), ui, options, id, self.reborrow());
+                    return;
+                }
+            }
         }
 
         if let Some(()) = (self.short_circuit_readonly)(self, value, ui, id, options) {
@@ -353,12 +359,15 @@ impl InspectorUi<'_, '_> {
         let info = registration.type_info();
 
         let mut options = options;
-        if options.is::<()>()
-            && let Some(data) = self
+        if options.is::<()>() {
+            if let Some(data) = self
                 .type_registry
                 .get_type_data::<ReflectInspectorOptions>(type_id)
-        {
-            options = &data.0;
+            {
+                {
+                    options = &data.0;
+                }
+            }
         }
 
         if let Some(s) = self
@@ -1682,11 +1691,12 @@ impl InspectorUi<'_, '_> {
                                 }
                             });*/
 
-                            if variant_label_response.clicked()
-                                && let Ok(dynamic_enum) =
+                            if variant_label_response.clicked() {
+                                if let Ok(dynamic_enum) =
                                     self.construct_default_variant(variant, ui)
-                            {
-                                changed_variant = Some((i, dynamic_enum));
+                                {
+                                    changed_variant = Some((i, dynamic_enum));
+                                }
                             };
                         });
                     }


### PR DESCRIPTION
Hi!

I replaced the if let && statements that were introduced in 0.32.0. They do not compile as this combination is unstable. I assume they were written and compiled in nightly Rust? Nested if expressions make this available to everyone.

All examples work fine. Only "inspector_options" does not show an EGUI but I cannot tell where this issue is from.

Best wishes
Florian