### PR TITLE
Removed empty `dbg!()` calls from `reflect_inspector/mod.rs`

### DIFF
--- a/crates/bevy-inspector-egui/src/reflect_inspector/mod.rs
+++ b/crates/bevy-inspector-egui/src/reflect_inspector/mod.rs
@@ -1035,12 +1035,8 @@ impl InspectorUi<'_, '_> {
         });
 
         let map_info = map.get_represented_map_info()?;
-
-        dbg!();
         let key_default = self.get_reflect_default(map_info.key_ty().id())?;
-        dbg!();
         let value_default = self.get_reflect_default(map_info.value_ty().id())?;
-        dbg!();
 
         ui.separator();
         ui.end_row();


### PR DESCRIPTION
Fixes #272 

Removes empty dbg! statements presumably accidentally left in `reflect_inspector/mod.rs` from testing.

Noticeable when opening the inspector on anything containing a HashMap.

