### PR TITLE
Customizable relationships in Inspector and Hierarchy windows

### DIFF
--- a/crates/bevy-inspector-egui/Cargo.toml
+++ b/crates/bevy-inspector-egui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy-inspector-egui"
-version = "0.33.1"
+version = "0.33.2"
 edition = "2024"
 repository = "https://github.com/jakobhellermann/bevy-inspector-egui/"
 readme = "README.md"

--- a/crates/bevy-inspector-egui/src/bevy_inspector/hierarchy.rs
+++ b/crates/bevy-inspector-egui/src/bevy_inspector/hierarchy.rs
@@ -50,7 +50,7 @@ pub struct Hierarchy<'a, T = ()> {
 }
 
 impl<T> Hierarchy<'_, T> {
-    fn default_children_getter() -> impl Fn(&World, Entity) -> Option<Vec<Entity>> {
+    pub fn default_children_getter() -> impl Fn(&World, Entity) -> Option<Vec<Entity>> {
         |world: &World, entity: Entity| {
             world
                 .get::<Children>(entity)
@@ -58,7 +58,7 @@ impl<T> Hierarchy<'_, T> {
         }
     }
 
-    fn default_parent_getter() -> impl Fn(&World, Entity) -> Option<Entity> {
+    pub fn default_parent_getter() -> impl Fn(&World, Entity) -> Option<Entity> {
         |world: &World, entity: Entity| world.get::<ChildOf>(entity).map(|c| c.parent())
     }
 

--- a/crates/bevy-inspector-egui/src/bevy_inspector/hierarchy.rs
+++ b/crates/bevy-inspector-egui/src/bevy_inspector/hierarchy.rs
@@ -3,19 +3,14 @@ use std::collections::HashSet;
 use crate::bevy_inspector::{EntityFilter, Filter};
 use crate::utils::guess_entity_name;
 use bevy_ecs::{prelude::*, query::QueryFilter};
-use bevy_reflect::TypeRegistry;
 use egui::{CollapsingHeader, RichText};
 
 /// Display UI of the entity hierarchy.
 ///
 /// Returns `true` if a new entity was selected.
 pub fn hierarchy_ui(world: &mut World, ui: &mut egui::Ui, selected: &mut SelectedEntities) -> bool {
-    let type_registry = world.resource::<AppTypeRegistry>().clone();
-    let type_registry = type_registry.read();
-
     Hierarchy {
         world,
-        type_registry: &type_registry,
         selected,
         context_menu: None,
         shortcircuit_entity: None,
@@ -35,12 +30,8 @@ pub fn hierarchy_ui_filtered<QF>(
 where
     QF: QueryFilter,
 {
-    let type_registry = world.resource::<AppTypeRegistry>().clone();
-    let type_registry = type_registry.read();
-
     Hierarchy {
         world,
-        type_registry: &type_registry,
         selected,
         context_menu: None,
         shortcircuit_entity: None,
@@ -51,7 +42,6 @@ where
 
 pub struct Hierarchy<'a, T = ()> {
     pub world: &'a mut World,
-    pub type_registry: &'a TypeRegistry,
     pub selected: &'a mut SelectedEntities,
     pub context_menu: Option<&'a mut dyn FnMut(&mut egui::Ui, Entity, &mut World, &mut T)>,
     pub shortcircuit_entity:

--- a/crates/bevy-inspector-egui/src/bevy_inspector/hierarchy.rs
+++ b/crates/bevy-inspector-egui/src/bevy_inspector/hierarchy.rs
@@ -165,9 +165,6 @@ impl<T> Hierarchy<'_, T> {
         let header_response = response.header_response;
 
         if header_response.clicked() {
-            let selection_mode = ui.input(|input| {
-                SelectionMode::from_ctrl_shift(input.modifiers.ctrl, input.modifiers.shift)
-            });
             let extend_with = |from, to| {
                 // PERF: this could be done in one scan
                 let from_position = at_same_level.iter().position(|&entity| entity == from);
@@ -181,6 +178,7 @@ impl<T> Hierarchy<'_, T> {
                     .into_iter()
                     .flatten()
             };
+            let selection_mode = ui.input(|input| input.modifiers.into());
             self.selected.select(selection_mode, entity, extend_with);
             new_selection = true;
         }
@@ -235,9 +233,9 @@ pub enum SelectionMode {
     Extend,
 }
 
-impl SelectionMode {
-    pub fn from_ctrl_shift(ctrl: bool, shift: bool) -> SelectionMode {
-        match (ctrl, shift) {
+impl From<egui::Modifiers> for SelectionMode {
+    fn from(modifiers: egui::Modifiers) -> Self {
+        match (modifiers.ctrl, modifiers.shift) {
             (true, _) => SelectionMode::Add,
             (false, true) => SelectionMode::Extend,
             (false, false) => SelectionMode::Replace,

--- a/crates/bevy-inspector-egui/src/bevy_inspector/hierarchy.rs
+++ b/crates/bevy-inspector-egui/src/bevy_inspector/hierarchy.rs
@@ -151,9 +151,8 @@ impl<T> Hierarchy<'_, T> {
             return false;
         }
 
-        #[allow(deprecated)] // the suggested replacement doesn't really work
         let response = CollapsingHeader::new(name)
-            .id_source(entity)
+            .id_salt(entity)
             .icon(move |ui, openness, response| {
                 if !has_children {
                     return;

--- a/crates/bevy-inspector-egui/src/bevy_inspector/hierarchy.rs
+++ b/crates/bevy-inspector-egui/src/bevy_inspector/hierarchy.rs
@@ -50,68 +50,128 @@ pub struct Hierarchy<'a, T = ()> {
 }
 
 impl<T> Hierarchy<'_, T> {
+    fn default_children_getter() -> impl Fn(&World, Entity) -> Option<Vec<Entity>> {
+        |world: &World, entity: Entity| {
+            world
+                .get::<Children>(entity)
+                .map(|children| children.iter().collect::<Vec<_>>())
+        }
+    }
+
+    fn default_parent_getter() -> impl Fn(&World, Entity) -> Option<Entity> {
+        |world: &World, entity: Entity| world.get::<ChildOf>(entity).map(|c| c.parent())
+    }
+
     pub fn show<QF>(&mut self, ui: &mut egui::Ui) -> bool
     where
         QF: QueryFilter,
     {
         let filter: Filter = Filter::all();
-        self._show::<QF, _>(ui, filter)
+        self._show::<QF, _, _, _>(
+            ui,
+            filter,
+            Self::default_children_getter(),
+            Self::default_parent_getter(),
+        )
     }
     pub fn show_with_default_filter<QF>(&mut self, ui: &mut egui::Ui) -> bool
     where
         QF: QueryFilter,
     {
         let filter: Filter = Filter::from_ui(ui, egui::Id::new("default_hierarchy_filter"));
-        self._show::<QF, _>(ui, filter)
+        self._show::<QF, _, _, _>(
+            ui,
+            filter,
+            Self::default_children_getter(),
+            Self::default_parent_getter(),
+        )
     }
     pub fn show_with_filter<QF, F>(&mut self, ui: &mut egui::Ui, filter: F) -> bool
     where
         QF: QueryFilter,
         F: EntityFilter,
     {
-        self._show::<QF, F>(ui, filter)
+        self._show::<QF, F, _, _>(
+            ui,
+            filter,
+            Self::default_children_getter(),
+            Self::default_parent_getter(),
+        )
     }
-    fn _show<QF, F>(&mut self, ui: &mut egui::Ui, filter: F) -> bool
+
+    pub fn show_with_filter_and_getters<QF, F, CG, PG>(
+        &mut self,
+        ui: &mut egui::Ui,
+        filter: F,
+        children_getter: CG,
+        parent_getter: PG,
+    ) -> bool
     where
         QF: QueryFilter,
         F: EntityFilter,
+        CG: Fn(&World, Entity) -> Option<Vec<Entity>>,
+        PG: Fn(&World, Entity) -> Option<Entity>,
     {
-        let mut root_query = self
-            .world
-            .query_filtered::<Entity, (Without<ChildOf>, QF)>();
+        self._show::<QF, F, CG, PG>(ui, filter, children_getter, parent_getter)
+    }
 
+    fn _show<QF, F, CG, PG>(
+        &mut self,
+        ui: &mut egui::Ui,
+        filter: F,
+        children_getter: CG,
+        parent_getter: PG,
+    ) -> bool
+    where
+        QF: QueryFilter,
+        F: EntityFilter,
+        CG: Fn(&World, Entity) -> Option<Vec<Entity>>,
+        PG: Fn(&World, Entity) -> Option<Entity>,
+    {
         let always_open: HashSet<Entity> = self
             .selected
             .iter()
             .flat_map(|selected| {
-                std::iter::successors(Some(selected), |&entity| {
-                    self.world.get::<ChildOf>(entity).map(|c| c.0)
-                })
-                .skip(1)
+                std::iter::successors(Some(selected), |&entity| parent_getter(self.world, entity))
+                    .skip(1)
             })
             .collect();
 
-        let mut entities: Vec<_> = root_query.iter(self.world).collect();
+        let mut root_query = self.world.query_filtered::<Entity, QF>();
+        let mut entities: Vec<_> = root_query
+            .iter(self.world)
+            .filter(|&entity| parent_getter(self.world, entity).is_none())
+            .collect();
+
         filter.filter_entities(self.world, &mut entities);
         entities.sort();
 
         let mut selected = false;
         for &entity in &entities {
-            selected |= self.entity_ui(ui, entity, &always_open, &entities, &filter);
+            selected |= self.entity_ui(
+                ui,
+                entity,
+                &always_open,
+                &entities,
+                &filter,
+                &children_getter,
+            );
         }
         selected
     }
 
-    fn entity_ui<F>(
+    fn entity_ui<F, CG>(
         &mut self,
         ui: &mut egui::Ui,
         entity: Entity,
         always_open: &HashSet<Entity>,
         at_same_level: &[Entity],
         filter: &F,
+        get_children: &CG,
     ) -> bool
     where
         F: EntityFilter,
+        CG: Fn(&World, Entity) -> Option<Vec<Entity>>,
     {
         let mut new_selection = false;
         let selected = self.selected.contains(entity);
@@ -122,9 +182,8 @@ impl<T> Hierarchy<'_, T> {
             name = name.strong();
         }
 
-        let has_children = self
-            .world
-            .get::<Children>(entity)
+        let has_children = get_children(self.world, entity)
+            .as_ref()
             .is_some_and(|children| !children.is_empty());
 
         let open = if !has_children {
@@ -151,12 +210,11 @@ impl<T> Hierarchy<'_, T> {
             })
             .open(open)
             .show(ui, |ui| {
-                let children = self.world.get::<Children>(entity);
-                if let Some(children) = children {
-                    let mut children = children.to_vec();
+                if let Some(mut children) = get_children(self.world, entity) {
                     filter.filter_entities(self.world, &mut children);
                     for &child in &children {
-                        new_selection |= self.entity_ui(ui, child, always_open, &children, filter);
+                        new_selection |=
+                            self.entity_ui(ui, child, always_open, &children, filter, get_children);
                     }
                 } else {
                     ui.label("No children");

--- a/crates/bevy-inspector-egui/src/bevy_inspector/mod.rs
+++ b/crates/bevy-inspector-egui/src/bevy_inspector/mod.rs
@@ -327,6 +327,9 @@ pub trait EntityFilter {
         entities.retain(|&entity| self.filter_entity(world, entity));
     }
 
+    /// Get children entities for the given entity
+    fn get_children(&self, world: &World, entity: Entity) -> Option<Vec<Entity>>;
+
     /// Returns true if entity matches the filter term
     fn filter_entity(&self, world: &mut World, entity: Entity) -> bool;
 }
@@ -336,6 +339,7 @@ pub struct Filter<F: QueryFilter = Without<ChildOf>> {
     pub word: String,
     pub is_fuzzy: bool,
     pub show_observers: bool,
+    pub get_children: Option<fn(&World, Entity) -> Option<Vec<Entity>>>,
     pub marker: PhantomData<F>,
 }
 
@@ -345,6 +349,7 @@ impl<F: QueryFilter + Clone> Clone for Filter<F> {
             word: self.word.clone(),
             is_fuzzy: self.is_fuzzy,
             show_observers: self.show_observers,
+            get_children: self.get_children,
             marker: PhantomData,
         }
     }
@@ -384,6 +389,7 @@ impl<F: QueryFilter> Filter<F> {
                 word,
                 is_fuzzy: true,
                 show_observers,
+                get_children: None,
                 marker: PhantomData,
             }
         })
@@ -438,6 +444,7 @@ impl<F: QueryFilter> Filter<F> {
                 word,
                 is_fuzzy,
                 show_observers: hide_observers,
+                get_children: None,
                 marker: PhantomData,
             }
         })
@@ -450,6 +457,7 @@ impl<F: QueryFilter> Filter<F> {
             word: String::from(""),
             is_fuzzy: false,
             show_observers: true,
+            get_children: None,
             marker: PhantomData,
         }
     }
@@ -469,17 +477,32 @@ impl<F: QueryFilter> EntityFilter for Filter<F> {
             self.word.as_str(),
             self.is_fuzzy,
             self.show_observers,
+            &|world, entity| self.get_children(world, entity),
         )
+    }
+
+    fn get_children(&self, world: &World, entity: Entity) -> Option<Vec<Entity>> {
+        if let Some(getter) = self.get_children {
+            getter(world, entity)
+        } else {
+            world
+                .get::<Children>(entity)
+                .map(|children| children.iter().collect())
+        }
     }
 }
 
-fn self_or_children_satisfy_filter(
+fn self_or_children_satisfy_filter<G>(
     world: &mut World,
     entity: Entity,
     filter: &str,
     is_fuzzy: bool,
     show_observers: bool,
-) -> bool {
+    get_children: &G,
+) -> bool
+where
+    G: Fn(&World, Entity) -> Option<Vec<Entity>>,
+{
     let name = guess_entity_name(world, entity);
 
     let is_hidden_observer = !show_observers
@@ -495,16 +518,19 @@ fn self_or_children_satisfy_filter(
         name.to_lowercase().contains(filter)
     };
     !is_hidden_observer && self_matches || {
-        let Ok(children) = world
-            .query::<&Children>()
-            .get(world, entity)
-            .map(|children| children.to_vec())
-        else {
+        let Some(children) = get_children(world, entity) else {
             return false;
         };
 
         children.iter().any(|child| {
-            self_or_children_satisfy_filter(world, *child, filter, is_fuzzy, show_observers)
+            self_or_children_satisfy_filter(
+                world,
+                *child,
+                filter,
+                is_fuzzy,
+                show_observers,
+                get_children,
+            )
         })
     }
 }

--- a/crates/bevy-inspector-egui/src/bevy_inspector/mod.rs
+++ b/crates/bevy-inspector-egui/src/bevy_inspector/mod.rs
@@ -272,9 +272,6 @@ pub fn ui_for_entities_filtered<F>(
 ) where
     F: EntityFilter,
 {
-    let type_registry = world.resource::<AppTypeRegistry>().0.clone();
-    let type_registry = type_registry.read();
-
     let mut root_entities = world.query_filtered::<Entity, F::StaticFilter>();
     let mut entities = root_entities.iter(world).collect::<Vec<_>>();
 
@@ -292,24 +289,10 @@ pub fn ui_for_entities_filtered<F>(
             .id_salt(id)
             .show(ui, |ui| {
                 if with_children {
-                    ui_for_entity_with_children_inner(
-                        world,
-                        entity,
-                        ui,
-                        id,
-                        &type_registry,
-                        filter,
-                    );
+                    ui_for_entity_with_children_inner(world, entity, ui, id, filter);
                 } else {
                     let mut queue = CommandQueue::default();
-                    ui_for_entity_components(
-                        &mut world.into(),
-                        Some(&mut queue),
-                        entity,
-                        ui,
-                        id,
-                        &type_registry,
-                    );
+                    ui_for_entity_components(&mut world.into(), Some(&mut queue), entity, ui, id);
                     queue.apply(world);
                 }
             });
@@ -524,21 +507,11 @@ fn self_or_children_satisfy_filter(
 
 /// Display the given entity with all its components and children
 pub fn ui_for_entity_with_children(world: &mut World, entity: Entity, ui: &mut egui::Ui) {
-    let type_registry = world.resource::<AppTypeRegistry>().0.clone();
-    let type_registry = type_registry.read();
-
     let entity_name = guess_entity_name(world, entity);
     ui.label(entity_name);
 
     let filter: Filter = Filter::all();
-    ui_for_entity_with_children_inner(
-        world,
-        entity,
-        ui,
-        egui::Id::new(entity),
-        &type_registry,
-        &filter,
-    )
+    ui_for_entity_with_children_inner(world, entity, ui, egui::Id::new(entity), &filter)
 }
 
 fn ui_for_entity_with_children_inner<F>(
@@ -546,20 +519,12 @@ fn ui_for_entity_with_children_inner<F>(
     entity: Entity,
     ui: &mut egui::Ui,
     id: egui::Id,
-    type_registry: &TypeRegistry,
     filter: &F,
 ) where
     F: EntityFilter,
 {
     let mut queue = CommandQueue::default();
-    ui_for_entity_components(
-        &mut world.into(),
-        Some(&mut queue),
-        entity,
-        ui,
-        id,
-        type_registry,
-    );
+    ui_for_entity_components(&mut world.into(), Some(&mut queue), entity, ui, id);
 
     let children = world
         .get::<Children>(entity)
@@ -578,7 +543,7 @@ fn ui_for_entity_with_children_inner<F>(
                 .show(ui, |ui| {
                     ui.label(&child_entity_name);
 
-                    ui_for_entity_with_children_inner(world, child, ui, id, type_registry, filter);
+                    ui_for_entity_with_children_inner(world, child, ui, id, filter);
                 });
         }
     }
@@ -588,9 +553,6 @@ fn ui_for_entity_with_children_inner<F>(
 
 /// Display the components of the given entity
 pub fn ui_for_entity(world: &mut World, entity: Entity, ui: &mut egui::Ui) {
-    let type_registry = world.resource::<AppTypeRegistry>().0.clone();
-    let type_registry = type_registry.read();
-
     let entity_name = guess_entity_name(world, entity);
     ui.label(entity_name);
 
@@ -601,7 +563,6 @@ pub fn ui_for_entity(world: &mut World, entity: Entity, ui: &mut egui::Ui) {
         entity,
         ui,
         egui::Id::new(entity),
-        &type_registry,
     );
     queue.apply(world);
 }
@@ -613,8 +574,9 @@ pub(crate) fn ui_for_entity_components(
     entity: Entity,
     ui: &mut egui::Ui,
     id: egui::Id,
-    type_registry: &TypeRegistry,
 ) {
+    let type_registry = world.get_resource_mut::<AppTypeRegistry>().unwrap().clone();
+    let type_registry = type_registry.read();
     let Ok(components) = components_of_entity(world, entity) else {
         errors::entity_does_not_exist(ui, entity);
         return;
@@ -655,7 +617,7 @@ pub(crate) fn ui_for_entity_components(
         let value = match component_view.get_entity_component_reflect(
             entity,
             component_type_id,
-            type_registry,
+            &type_registry,
         ) {
             Ok(value) => value,
             Err(e) => {
@@ -675,7 +637,7 @@ pub(crate) fn ui_for_entity_components(
         let _response = header.show(ui, |ui| {
             ui.reset_style();
 
-            let mut env = InspectorUi::for_bevy(type_registry, &mut cx);
+            let mut env = InspectorUi::for_bevy(&type_registry, &mut cx);
             let id = id.with(component_id);
             let options = &();
 

--- a/crates/bevy-inspector-egui/src/inspector_egui_impls/bevy_impls.rs
+++ b/crates/bevy-inspector-egui/src/inspector_egui_impls/bevy_impls.rs
@@ -73,7 +73,6 @@ impl InspectorPrimitive for Entity {
                             entity,
                             ui,
                             id,
-                            env.type_registry,
                         );
                         if options.despawnable
                             && world.contains_entity(entity)


### PR DESCRIPTION
Added support for custom parent-child relationships in the Hierarchy and Inspector windows.
and some refactoring, less TypeRegistry forwarding, fixed deprecation, build SelectionMode from input.modifiers using rust From trait.

<img width="1594" height="623" alt="image" src="https://github.com/user-attachments/assets/5ee1080c-68b1-4508-a359-36c0dc8cc4b0" />
