### PR TITLE
Bump egui to 0.33

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,5 +3,5 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.dependencies]
-egui = "0.32"
-bevy_egui = "0.37"
+egui = "0.33"
+bevy_egui = "0.38"

--- a/crates/bevy-inspector-egui/src/egui_utils.rs
+++ b/crates/bevy-inspector-egui/src/egui_utils.rs
@@ -270,7 +270,7 @@ pub mod easymark {
 
         fn numbered_point(ui: &mut Ui, width: f32, number: &str) -> Response {
             let font_id = TextStyle::Body.resolve(ui.style());
-            let row_height = ui.fonts(|fonts| fonts.row_height(&font_id));
+            let row_height = ui.fonts_mut(|fonts| fonts.row_height(&font_id));
             let (rect, response) = ui.allocate_exact_size(vec2(width, row_height), Sense::hover());
             let text = format!("{number}.");
             let text_color = ui.visuals().strong_text_color();


### PR DESCRIPTION
Adds compatibility for projects using egui 0.33.

Related: https://github.com/jakobhellermann/bevy-inspector-egui/issues/289