### PR TITLE
Fix; picking and selection interaction with the transform_gizmo_bevy

### DIFF
--- a/crates/bevy-inspector-egui/examples/integrations/egui_dock.rs
+++ b/crates/bevy-inspector-egui/examples/integrations/egui_dock.rs
@@ -451,6 +451,7 @@ fn setup(
 
     // egui camera
     commands.spawn((
+        Pickable{ should_block_lower: false, is_hoverable: false },
         Camera2d,
         Name::new("Egui Camera"),
         PrimaryEguiContext,

--- a/crates/bevy-inspector-egui/examples/integrations/egui_dock.rs
+++ b/crates/bevy-inspector-egui/examples/integrations/egui_dock.rs
@@ -58,6 +58,12 @@ fn handle_pick_events(
     mut commands: Commands,
 ) {
     if !ui_state.pointer_in_viewport {
+        gizmo_targets
+            .iter()
+            .for_each(|(entity, _)| {commands.entity(entity).remove::<GizmoTarget>();});
+        for entity in ui_state.selected_entities.iter() {
+            commands.entity(entity).insert_if_new(GizmoTarget::default());
+        }
         return;
     }
     for event in click_events.read() {


### PR DESCRIPTION
the example only selected the Egui camera, fixed by disabling picking of the Egui camera.
After this I discovered a bug with the selection logic, where selection from the heirarcy didn't update which entities had the GizmoTarget component; fixed by clearing all GizmoTargets, then adding GizmoTarget to all selected entities, when pointer interaction is outside the viewport.
There is still some undesireable behavioir with selecting resources or assets for inspection, where the GizmoTargets stay active.