### PR TITLE
Fix blank screen for inspector_options example

### DIFF
--- a/crates/bevy-inspector-egui/examples/basic/inspector_options.rs
+++ b/crates/bevy-inspector-egui/examples/basic/inspector_options.rs
@@ -81,6 +81,8 @@ fn main() {
 }
 
 fn setup(mut commands: Commands, mut ui_data: ResMut<UiData>) {
+    commands.spawn(Camera2d);
+
     let entity = commands.spawn(Mesh3d::default()).id();
     ui_data.entity = Some(entity);
 }


### PR DESCRIPTION
Simple fix for the inspector_options example being a blank screen:

#299 