### PR TITLE
Support Disabled entities with global toggle and new Enable/Disable buttons

### DIFF
--- a/crates/bevy-inspector-egui/examples/quick/world_inspector.rs
+++ b/crates/bevy-inspector-egui/examples/quick/world_inspector.rs
@@ -30,12 +30,25 @@ fn setup(
         Mesh3d(meshes.add(Cuboid::new(1.0, 1.0, 1.0))),
         MeshMaterial3d(materials.add(Color::srgba(255., 181. / 255., 0., 102. / 255.))),
         Transform::from_xyz(0.0, 0.5, 0.0),
-        children![(
-            Name::new("My Sphere"),
-            Mesh3d(meshes.add(Sphere::default().mesh())),
-            MeshMaterial3d(materials.add(Color::srgba(0., 162. / 255., 232. / 255., 153. / 255.))),
-            Transform::from_xyz(1.0, 1.0, 0.0),
-        )],
+        children![
+            (
+                Name::new("My First Sphere"),
+                Mesh3d(meshes.add(Sphere::default().mesh())),
+                MeshMaterial3d(materials.add(Color::srgba(
+                    0.,
+                    162. / 255.,
+                    232. / 255.,
+                    153. / 255.
+                ))),
+                Transform::from_xyz(1.0, 1.0, 0.0),
+            ),
+            (
+                Name::new("My Second Sphere"),
+                Mesh3d(meshes.add(Sphere::default().mesh())),
+                MeshMaterial3d(materials.add(Color::srgba(255., 0., 255., 153. / 255.))),
+                Transform::from_xyz(-1.0, 1.0, 0.0),
+            ),
+        ],
     ));
     // light
     commands.spawn((

--- a/crates/bevy-inspector-egui/examples/quick/world_inspector.rs
+++ b/crates/bevy-inspector-egui/examples/quick/world_inspector.rs
@@ -30,6 +30,12 @@ fn setup(
         Mesh3d(meshes.add(Cuboid::new(1.0, 1.0, 1.0))),
         MeshMaterial3d(materials.add(Color::srgba(255., 181. / 255., 0., 102. / 255.))),
         Transform::from_xyz(0.0, 0.5, 0.0),
+        children![(
+            Name::new("My Sphere"),
+            Mesh3d(meshes.add(Sphere::default().mesh())),
+            MeshMaterial3d(materials.add(Color::srgba(0., 162. / 255., 232. / 255., 153. / 255.))),
+            Transform::from_xyz(1.0, 1.0, 0.0),
+        )],
     ));
     // light
     commands.spawn((

--- a/crates/bevy-inspector-egui/src/bevy_inspector/mod.rs
+++ b/crates/bevy-inspector-egui/src/bevy_inspector/mod.rs
@@ -601,6 +601,13 @@ fn ui_for_entity_with_children_inner<F>(
         && !children.is_empty()
     {
         filter.filter_entities(world, &mut children);
+
+        // Check if we should show disabled entities.
+        let show_disabled = ui.memory_mut(|mem| {
+            *mem.data
+                .get_persisted_mut_or_insert_with(egui::Id::new("show_disabled_entities"), || false)
+        });
+
         ui.label("Children");
         for child in children {
             let id = id.with(child);
@@ -611,6 +618,11 @@ fn ui_for_entity_with_children_inner<F>(
             let is_disabled = world
                 .get::<bevy_ecs::entity_disabling::Disabled>(child)
                 .is_some();
+
+            // Skip rendering disabled entities if the toggle is off.
+            if is_disabled && !show_disabled {
+                continue;
+            }
 
             if is_disabled {
                 ui.style_mut().visuals.override_text_color = Some(egui::Color32::DARK_GRAY);

--- a/crates/bevy-inspector-egui/src/bevy_inspector/mod.rs
+++ b/crates/bevy-inspector-egui/src/bevy_inspector/mod.rs
@@ -824,7 +824,7 @@ fn ui_for_entity_buttons(
             .unwrap_or(false);
 
         if has_disabled {
-            if crate::egui_utils::label_button(ui, "✓ Enable", egui::Color32::GREEN) {
+            if crate::egui_utils::label_button(ui, "✔ Enable", egui::Color32::GREEN) {
                 queue.push(move |world: &mut World| {
                     world.entity_mut(entity).remove::<Disabled>();
                 });

--- a/crates/bevy-inspector-egui/src/bevy_inspector/mod.rs
+++ b/crates/bevy-inspector-egui/src/bevy_inspector/mod.rs
@@ -579,7 +579,7 @@ fn ui_for_entity_with_children_inner<F>(
     ui: &mut egui::Ui,
     id: egui::Id,
     type_registry: &TypeRegistry,
-    filter: &F,
+    _filter: &F,
 ) where
     F: EntityFilter,
 {
@@ -593,46 +593,6 @@ fn ui_for_entity_with_children_inner<F>(
         type_registry,
     );
     ui_for_entity_buttons(world, entity, ui, &mut queue);
-
-    let children = world
-        .get::<Children>(entity)
-        .map(|children| children.iter().collect::<Vec<_>>());
-    if let Some(mut children) = children
-        && !children.is_empty()
-    {
-        filter.filter_entities(world, &mut children);
-        ui.label("Children");
-        for child in children {
-            let id = id.with(child);
-
-            let child_entity_name = guess_entity_name(world, child);
-
-            // Grey out disabled entities.
-            let is_disabled = world
-                .get::<bevy_ecs::entity_disabling::Disabled>(child)
-                .is_some();
-
-            if is_disabled {
-                ui.style_mut().visuals.override_text_color = Some(egui::Color32::DARK_GRAY);
-            }
-
-            egui::CollapsingHeader::new(&child_entity_name)
-                .id_salt(id)
-                .show(ui, |ui| {
-                    // Reset text color override so content doesn't inherit it
-                    ui.style_mut().visuals.override_text_color = None;
-
-                    ui.label(&child_entity_name);
-
-                    ui_for_entity_with_children_inner(world, child, ui, id, type_registry, filter);
-                });
-
-            // Reset text color override after header so next entity doesn't inherit it
-            if is_disabled {
-                ui.style_mut().visuals.override_text_color = None;
-            }
-        }
-    }
 
     queue.apply(world);
 }

--- a/crates/bevy-inspector-egui/src/bevy_inspector/mod.rs
+++ b/crates/bevy-inspector-egui/src/bevy_inspector/mod.rs
@@ -579,7 +579,7 @@ fn ui_for_entity_with_children_inner<F>(
     ui: &mut egui::Ui,
     id: egui::Id,
     type_registry: &TypeRegistry,
-    _filter: &F,
+    filter: &F,
 ) where
     F: EntityFilter,
 {
@@ -593,6 +593,46 @@ fn ui_for_entity_with_children_inner<F>(
         type_registry,
     );
     ui_for_entity_buttons(world, entity, ui, &mut queue);
+
+    let children = world
+        .get::<Children>(entity)
+        .map(|children| children.iter().collect::<Vec<_>>());
+    if let Some(mut children) = children
+        && !children.is_empty()
+    {
+        filter.filter_entities(world, &mut children);
+        ui.label("Children");
+        for child in children {
+            let id = id.with(child);
+
+            let child_entity_name = guess_entity_name(world, child);
+
+            // Grey out disabled entities.
+            let is_disabled = world
+                .get::<bevy_ecs::entity_disabling::Disabled>(child)
+                .is_some();
+
+            if is_disabled {
+                ui.style_mut().visuals.override_text_color = Some(egui::Color32::DARK_GRAY);
+            }
+
+            egui::CollapsingHeader::new(&child_entity_name)
+                .id_salt(id)
+                .show(ui, |ui| {
+                    // Reset text color override so content doesn't inherit it
+                    ui.style_mut().visuals.override_text_color = None;
+
+                    ui.label(&child_entity_name);
+
+                    ui_for_entity_with_children_inner(world, child, ui, id, type_registry, filter);
+                });
+
+            // Reset text color override after header so next entity doesn't inherit it
+            if is_disabled {
+                ui.style_mut().visuals.override_text_color = None;
+            }
+        }
+    }
 
     queue.apply(world);
 }

--- a/crates/bevy-inspector-egui/src/inspector_egui_impls/bevy_impls.rs
+++ b/crates/bevy-inspector-egui/src/inspector_egui_impls/bevy_impls.rs
@@ -117,7 +117,7 @@ impl InspectorPrimitive for Entity {
                                 if has_disabled {
                                     if egui_utils::label_button(
                                         ui,
-                                        "✓ Enable",
+                                        "✔ Enable",
                                         egui::Color32::GREEN,
                                     ) {
                                         queue.push(move |world: &mut World| {

--- a/crates/bevy-inspector-egui/src/inspector_egui_impls/bevy_impls.rs
+++ b/crates/bevy-inspector-egui/src/inspector_egui_impls/bevy_impls.rs
@@ -62,9 +62,24 @@ impl InspectorPrimitive for Entity {
 
                 let entity_name =
                     crate::utils::guess_entity_name::guess_entity_name_restricted(world, entity);
+
+                // Grey out disabled entities.
+                let is_disabled = world
+                    .world()
+                    .get_entity(entity)
+                    .is_ok_and(|e| e.contains::<bevy_ecs::entity_disabling::Disabled>());
+
+                if is_disabled {
+                    ui.style_mut().visuals.override_text_color = Some(egui::Color32::DARK_GRAY);
+                }
+
                 egui::CollapsingHeader::new(entity_name)
                     .id_salt(id)
                     .show(ui, |ui| {
+                        // Reset text color override so content doesn't inherit
+                        // it.
+                        ui.style_mut().visuals.override_text_color = None;
+
                         let _queue = CommandQueue::default();
                         crate::bevy_inspector::ui_for_entity_components(
                             world,
@@ -122,6 +137,12 @@ impl InspectorPrimitive for Entity {
                             });
                         }
                     });
+
+                // Reset text color override after header so next entity doesn't
+                // inherit it.
+                if is_disabled {
+                    ui.style_mut().visuals.override_text_color = None;
+                }
             }
         }
         false

--- a/crates/bevy-inspector-egui/src/inspector_egui_impls/bevy_impls.rs
+++ b/crates/bevy-inspector-egui/src/inspector_egui_impls/bevy_impls.rs
@@ -69,6 +69,20 @@ impl InspectorPrimitive for Entity {
                     .get_entity(entity)
                     .is_ok_and(|e| e.contains::<bevy_ecs::entity_disabling::Disabled>());
 
+                // Check if we should show disabled entities.
+                let show_disabled = ui.memory_mut(|mem| {
+                    *mem.data
+                        .get_persisted_mut_or_insert_with(
+                            egui::Id::new("show_disabled_entities"),
+                            || false,
+                        )
+                });
+
+                // Skip rendering disabled entities if the toggle is off.
+                if is_disabled && !show_disabled {
+                    return false;
+                }
+
                 if is_disabled {
                     ui.style_mut().visuals.override_text_color = Some(egui::Color32::DARK_GRAY);
                 }

--- a/crates/bevy-inspector-egui/src/inspector_egui_impls/bevy_impls.rs
+++ b/crates/bevy-inspector-egui/src/inspector_egui_impls/bevy_impls.rs
@@ -71,11 +71,10 @@ impl InspectorPrimitive for Entity {
 
                 // Check if we should show disabled entities.
                 let show_disabled = ui.memory_mut(|mem| {
-                    *mem.data
-                        .get_persisted_mut_or_insert_with(
-                            egui::Id::new("show_disabled_entities"),
-                            || false,
-                        )
+                    *mem.data.get_persisted_mut_or_insert_with(
+                        egui::Id::new("show_disabled_entities"),
+                        || false,
+                    )
                 });
 
                 // Skip rendering disabled entities if the toggle is off.


### PR DESCRIPTION
A new global toggle on the `Entities` section to show/hide disabled entities:

<img width="355" height="330" alt="image" src="https://github.com/user-attachments/assets/673f8028-3548-4a6d-b493-e851af835ace" />

`Enable` and `Disable` buttons inside an entity to control whether or not they are disabled. Also fix root entities to show these buttons (including the `Despawn` button):

<img width="395" height="650" alt="image" src="https://github.com/user-attachments/assets/10fdab94-48a0-4e4d-af2b-33b3f0a573ae" />

When I disable the cube the inspector hides that entity:

<img width="392" height="288" alt="image" src="https://github.com/user-attachments/assets/1e98fca8-4feb-4145-84a4-8796487d520b" />

Until I check the "Show Disabled" global checkbox to show `Disabled`:

<img width="966" height="678" alt="image" src="https://github.com/user-attachments/assets/ba6d18fa-eb8e-46dd-8964-9b8af7453444" />

I can also disable a child entity:

<img width="957" height="760" alt="image" src="https://github.com/user-attachments/assets/15f0e62b-6a80-43ba-8ec9-315ed1c8b6d6" />

And if re-enable the cube and I untoggle the global checkbox, we see that the `Children` no longer shows the disabled entities. This is because we honor the global "Show Disabled" checkbox and if it's off we shouldn't show any disabled entities, even inside `Children`.

<img width="1082" height="726" alt="image" src="https://github.com/user-attachments/assets/78a36d60-3275-4ed3-9c4e-41e9136bb7b3" />

Note: After taking the screenshots I realised the tick character wasn't working. I fixed it:

<img width="193" height="105" alt="image" src="https://github.com/user-attachments/assets/d67f94e6-b086-43bb-a060-07a3a8bf4091" />

Note: I've used bevy-inspector-egui for a while and I've never understood why the root level entities do not have a `Despawn` button so as part of this change (adding `Enable` and `Disable` buttons) I decided to fix that.

Note: For me, the driver of this PR was using `bevy_enhanced_input` and when actions disable at runtime due to various reasons they disappear from the inspector and it makes it impossible to debug their state.

**Testing**

```
cargo run --example world_inspector
```