### PR TITLE
Update README to include EguiPlugin import

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ Displays the world's entities, resources and assets.
 
 ```rust
 use bevy::prelude::*;
-use bevy_inspector_egui::quick::WorldInspectorPlugin;
+use bevy_inspector_egui::{bevy_egui::EguiPlugin, quick::WorldInspectorPlugin};
+
 
 fn main() {
     App::new()


### PR DESCRIPTION
The quick example from the README didn't include the import for the EguiPlugin.