### PR TITLE
Reworked features

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Pair this with a crate like [`egui_dock`](https://docs.rs/egui_dock/latest/egui_
 - `highlight_changes` - highlight changed values every frame.
   Ideally this should be runtime-configurable, but it was implemented like this as a stopgap solution. If you'd like to configure this at runtime, please open an issue to let me know it's more of a priority.
 - `bevy_pbr` (default): register default options for `bevy_pbr` types. You should disable this if you don't use `bevy_pbr` to reduce the dependency footprint.
+- `bevy_mesh` (default): register default options for `bevy_mesh` types. You should disable this if you don't use `bevy_mesh` to reduce the dependency footprint.
 - `bevy_gizmos`: enable inspecting of `GizmoConfigGroup`
 
 ## FAQ

--- a/README.md
+++ b/README.md
@@ -121,11 +121,15 @@ Pair this with a crate like [`egui_dock`](https://docs.rs/egui_dock/latest/egui_
 
 ## Cargo features
 
+- `2d` (default): enable 2d-only dependencies
+- `3d` (default): enable 3d-only dependencies
+- `common` (default): enable common dependencies used in 2d and 3d
 - `highlight_changes` - highlight changed values every frame.
   Ideally this should be runtime-configurable, but it was implemented like this as a stopgap solution. If you'd like to configure this at runtime, please open an issue to let me know it's more of a priority.
-- `bevy_pbr` (default): register default options for `bevy_pbr` types. You should disable this if you don't use `bevy_pbr` to reduce the dependency footprint.
-- `bevy_mesh` (default): register default options for `bevy_mesh` types. You should disable this if you don't use `bevy_mesh` to reduce the dependency footprint.
-- `bevy_gizmos`: enable inspecting of `GizmoConfigGroup`
+- `bevy_mesh` - enable inspecting of `Mesh`.
+- `bevy_pbr` - register default options for `bevy_pbr` types.
+- `bevy_light` - register default options for `bevy_light` types.
+- `bevy_gizmos` - enable inspecting of `GizmoConfigGroup`.
 
 ## FAQ
 

--- a/crates/bevy-inspector-egui/Cargo.toml
+++ b/crates/bevy-inspector-egui/Cargo.toml
@@ -30,7 +30,7 @@ common = [
     "bevy_render",
 ]
 2d = ["common"]
-3d = ["bevy_mesh", "bevy_pbr", "common"]
+3d = ["bevy_light", "bevy_mesh", "bevy_pbr", "common"]
 
 # Enable showing documentation on hover.
 documentation = ["bevy_reflect/reflect_documentation"]
@@ -65,13 +65,13 @@ bevy_ecs = "0.18.0"
 bevy_log = "0.18.0"
 bevy_camera = "0.18.0"
 bevy_math = "0.18.0"
-bevy_light = "0.18.0"
 bevy_reflect = "0.18.0"
 bevy_state = "0.18.0"
 bevy_time = "0.18.0"
 bevy_utils = "0.18.0"
 bevy_window = "0.18.0"
 
+bevy_light = { version = "0.18.0", optional = true }
 bevy_mesh = { version = "0.18.0", optional = true }
 bevy_render = { version = "0.18.0", optional = true }
 bevy_core_pipeline = { version = "0.18.0", optional = true }

--- a/crates/bevy-inspector-egui/Cargo.toml
+++ b/crates/bevy-inspector-egui/Cargo.toml
@@ -27,11 +27,14 @@ bevy = [
     "bevy_gizmos",
     "bevy_image",
     "bevy_pbr",
+    "bevy_mesh",
     "bevy_render",
 ]
 # Enable showing documentation on hover.
 documentation = ["bevy_reflect/reflect_documentation"]
 
+# Show inspector UI for bevy_mesh types
+bevy_mesh = ["dep:bevy_mesh", "bevy_mesh/bevy_mikktspace"]
 # Show inspector UI for bevy_render types
 bevy_render = ["dep:bevy_render", "bevy_egui/render"]
 # Show inspector UI for bevy_gizmos types
@@ -60,7 +63,6 @@ bevy_ecs = "0.18.0"
 bevy_log = "0.18.0"
 bevy_camera = "0.18.0"
 bevy_math = "0.18.0"
-bevy_mesh = "0.18.0"
 bevy_light = "0.18.0"
 bevy_reflect = "0.18.0"
 bevy_state = "0.18.0"
@@ -68,6 +70,7 @@ bevy_time = "0.18.0"
 bevy_utils = "0.18.0"
 bevy_window = "0.18.0"
 
+bevy_mesh = { version = "0.18.0", optional = true }
 bevy_render = { version = "0.18.0", optional = true }
 bevy_core_pipeline = { version = "0.18.0", optional = true }
 bevy_pbr = { version = "0.18.0", optional = true }

--- a/crates/bevy-inspector-egui/Cargo.toml
+++ b/crates/bevy-inspector-egui/Cargo.toml
@@ -18,18 +18,20 @@ categories = [
 [features]
 default = [
     "documentation",
-    "bevy",
     "egui_clipboard",
+    # Collections
+    "2d",
+    "3d",
 ]
-# Enable inspector UI for all optional bevy types
-bevy = [
+common = [
     "bevy_core_pipeline",
     "bevy_gizmos",
     "bevy_image",
-    "bevy_pbr",
-    "bevy_mesh",
     "bevy_render",
 ]
+2d = ["common"]
+3d = ["bevy_mesh", "bevy_pbr", "common"]
+
 # Enable showing documentation on hover.
 documentation = ["bevy_reflect/reflect_documentation"]
 

--- a/crates/bevy-inspector-egui/src/inspector_egui_impls/bevy_impls.rs
+++ b/crates/bevy-inspector-egui/src/inspector_egui_impls/bevy_impls.rs
@@ -5,12 +5,10 @@ use bevy_ecs::world::World;
 use egui::Color32;
 use std::any::Any;
 
+#[cfg(feature = "bevy_mesh")]
+use ::{bevy_asset::Assets, bevy_asset::Handle, bevy_mesh::Mesh};
 #[cfg(feature = "bevy_render")]
 use ::bevy_camera::visibility::RenderLayers;
-#[cfg(feature = "bevy_mesh")]
-use ::{
-    bevy_asset::Assets, bevy_asset::Handle, bevy_mesh::Mesh,
-};
 
 #[cfg(feature = "bevy_mesh")]
 use crate::bevy_inspector::errors::{no_access, nonexistent_asset_handle};

--- a/crates/bevy-inspector-egui/src/inspector_egui_impls/bevy_impls.rs
+++ b/crates/bevy-inspector-egui/src/inspector_egui_impls/bevy_impls.rs
@@ -6,11 +6,13 @@ use egui::Color32;
 use std::any::Any;
 
 #[cfg(feature = "bevy_render")]
+use ::bevy_camera::visibility::RenderLayers;
+#[cfg(feature = "bevy_mesh")]
 use ::{
-    bevy_asset::Assets, bevy_asset::Handle, bevy_camera::visibility::RenderLayers, bevy_mesh::Mesh,
+    bevy_asset::Assets, bevy_asset::Handle, bevy_mesh::Mesh,
 };
 
-#[cfg(feature = "bevy_render")]
+#[cfg(feature = "bevy_mesh")]
 use crate::bevy_inspector::errors::{no_access, nonexistent_asset_handle};
 use crate::{
     bevy_inspector::errors::no_world_in_context,
@@ -94,7 +96,7 @@ impl InspectorPrimitive for Entity {
     }
 }
 
-#[cfg(feature = "bevy_render")]
+#[cfg(feature = "bevy_mesh")]
 impl InspectorPrimitive for Handle<Mesh> {
     fn ui(
         &mut self,
@@ -156,7 +158,7 @@ impl InspectorPrimitive for Handle<Mesh> {
     }
 }
 
-#[cfg(feature = "bevy_render")]
+#[cfg(feature = "bevy_mesh")]
 fn mesh_ui_inner(mesh: &Mesh, ui: &mut egui::Ui) {
     egui::Grid::new("mesh").show(ui, |ui| {
         ui.label("primitive_topology");

--- a/crates/bevy-inspector-egui/src/inspector_egui_impls/mod.rs
+++ b/crates/bevy-inspector-egui/src/inspector_egui_impls/mod.rs
@@ -328,8 +328,11 @@ pub fn register_bevy_impls(type_registry: &mut TypeRegistry) {
     #[cfg(feature = "bevy_render")]
     {
       type_registry.register::<bevy_camera::visibility::RenderLayers>();
-      add_of_with_many::<bevy_asset::Handle<bevy_mesh::Mesh>>(type_registry, many_unimplemented::<bevy_asset::Handle<bevy_mesh::Mesh>>);
       add::<bevy_camera::visibility::RenderLayers>(type_registry);
+    }
+    #[cfg(feature = "bevy_mesh")]
+    {
+      add_of_with_many::<bevy_asset::Handle<bevy_mesh::Mesh>>(type_registry, many_unimplemented::<bevy_asset::Handle<bevy_mesh::Mesh>>);
     }
     #[cfg(feature = "bevy_image")]
     {

--- a/crates/bevy-inspector-egui/src/inspector_options/default_options.rs
+++ b/crates/bevy-inspector-egui/src/inspector_options/default_options.rs
@@ -189,7 +189,7 @@ pub fn register_default_options(type_registry: &mut TypeRegistry) {
         );
     }
 
-    #[cfg(feature = "bevy_pbr")]
+    #[cfg(feature = "bevy_light")]
     {
         #[rustfmt::skip]
         insert_options_struct::<bevy_light::AmbientLight>(
@@ -217,17 +217,6 @@ pub fn register_default_options(type_registry: &mut TypeRegistry) {
         );
 
         #[rustfmt::skip]
-        insert_options_struct::<bevy_pbr::StandardMaterial>(
-            type_registry,
-            &[
-                ("perceptual_roughness", &NumberOptions::<f32>::between(0.089, 1.0)),
-                ("metallic", &NumberOptions::<f32>::normalized()),
-                ("reflectance", &NumberOptions::<f32>::normalized()),
-                ("depth_bias", &NumberOptions::<f32>::positive()),
-            ],
-        );
-
-        #[rustfmt::skip]
         insert_options_enum::<bevy_light::cluster::ClusterConfig>(
             type_registry,
             &[
@@ -236,6 +225,18 @@ pub fn register_default_options(type_registry: &mut TypeRegistry) {
             ],
         );
     }
+
+    #[rustfmt::skip]
+    #[cfg(feature = "bevy_pbr")]
+    insert_options_struct::<bevy_pbr::StandardMaterial>(
+        type_registry,
+        &[
+            ("perceptual_roughness", &NumberOptions::<f32>::between(0.089, 1.0)),
+            ("metallic", &NumberOptions::<f32>::normalized()),
+            ("reflectance", &NumberOptions::<f32>::normalized()),
+            ("depth_bias", &NumberOptions::<f32>::positive()),
+        ],
+    );
 
     #[rustfmt::skip]
     #[cfg(feature = "bevy_core_pipeline")]


### PR DESCRIPTION
This PR consists **mainly** of two commits:

- ### Add mesh related logic behind `bevy_mesh` feature (2ca6de9)
(Resolves #307, Resolves #310)
It puts mesh implementations and related logic under a new feature (`bevy_mesh`), makes the `bevy_mesh` dependency optional, and enables `bevy_mesh/bevy_mikktspace` under the new feature, this fixes the compilation error caused when bevy doesn't enable the mikktspace feature (this happens when using the `2d` collection in bevy and disabling default features in `bevy-inspector-egui`)

I made sure it compiled with each feature individually (`cargo check --no-default-features --feature bevy_render` would previously fail compilation).

- ### Add feature collections (47a3d9c)

This mimics what Bevy is doing with feature collections by adding `2d`, `3d`  and a `common` collection, by default both `2d` and `3d` are enabled, allowing it to work out-of-the-box with default features (`cargo add bevy-inspector-egui bevy_egui`) and with the possibility of reducing dependencies by just enabling one of them.

Any other commits after these two are just corrections.

---

@jakobhellermann do let me know if this is something you want to implement or not, if changes are needed and/or if you want separate PRs or just one commit.

---

Edit: wording.