### PR TITLE
fix: compile error with `bevy_render` if bevy does not includue `bevy_mikktspace`

### DIFF
--- a/crates/bevy-inspector-egui/Cargo.toml
+++ b/crates/bevy-inspector-egui/Cargo.toml
@@ -26,6 +26,7 @@ bevy = [
     "bevy_core_pipeline",
     "bevy_gizmos",
     "bevy_image",
+    "bevy_mikktspace",
     "bevy_pbr",
     "bevy_render",
 ]
@@ -34,6 +35,8 @@ documentation = ["bevy_reflect/reflect_documentation"]
 
 # Show inspector UI for bevy_render types
 bevy_render = ["dep:bevy_render", "bevy_egui/render"]
+# Include bevy mikktspace tangents in inspector UI for meshes
+bevy_mikktspace = ["dep:bevy_mikktspace"]
 # Show inspector UI for bevy_gizmos types
 bevy_gizmos = ["dep:bevy_gizmos"]
 # Show inspector UI for bevy_core_pipeline types
@@ -73,6 +76,7 @@ bevy_core_pipeline = { version = "0.18.0", optional = true }
 bevy_pbr = { version = "0.18.0", optional = true }
 bevy_image = { version = "0.18.0", optional = true }
 bevy_gizmos = { version = "0.18.0", optional = true }
+bevy_mikktspace = { version = "0.16.1", optional = true }
 
 egui.workspace = true
 bevy_egui = { version = "0.39", default-features = false }

--- a/crates/bevy-inspector-egui/src/inspector_egui_impls/bevy_impls.rs
+++ b/crates/bevy-inspector-egui/src/inspector_egui_impls/bevy_impls.rs
@@ -132,8 +132,12 @@ impl InspectorPrimitive for Handle<Mesh> {
                 mesh.compute_flat_normals();
             }
         });
-        if ui.button("Generate tangents").clicked() {
-            let _ = mesh.generate_tangents();
+
+        #[cfg(feature = "bevy_mikktspace")]
+        {
+            if ui.button("Generate tangents").clicked() {
+                let _ = mesh.generate_tangents();
+            }
         }
 
         false


### PR DESCRIPTION
This add a new cargo feature `bevy_mikktspace` that enables an optional dependency on that crate. This feature is enabled by the `bevy` feature.

Fixes #307 

I see there is another open pull request for this issue, but this one does not redesign the features so hopefully it can be reviewed more easily without getting in the way of future plans for that PR.
#309