### PR TITLE
Add "hide observers" checkbox to World Inspector

### DIFF
--- a/crates/bevy-inspector-egui/examples/basic/world_inspector_manual.rs
+++ b/crates/bevy-inspector-egui/examples/basic/world_inspector_manual.rs
@@ -12,7 +12,7 @@ fn main() {
         .run();
 }
 
-fn custom_world_inspector_ui(world: &mut World) {
+fn custom_world_inspector_ui(world: &mut World, mut hide_observers: Local<bool>) {
     let egui_context = world
         .query_filtered::<&mut EguiContext, With<PrimaryEguiContext>>()
         .single(world);
@@ -26,7 +26,7 @@ fn custom_world_inspector_ui(world: &mut World) {
         .default_size((400., 300.))
         .show(egui_context.get_mut(), |ui| {
             egui::ScrollArea::both().show(ui, |ui| {
-                bevy_inspector::ui_for_world(world, ui);
+                bevy_inspector::ui_for_world(world, ui, &mut hide_observers);
                 ui.allocate_space(ui.available_size());
             });
         });

--- a/crates/bevy-inspector-egui/src/bevy_inspector/mod.rs
+++ b/crates/bevy-inspector-egui/src/bevy_inspector/mod.rs
@@ -83,11 +83,11 @@ pub fn ui_for_value(value: &mut dyn Reflect, ui: &mut egui::Ui, world: &mut Worl
 }
 
 /// Display `Entities`, `Resources` and `Assets` using their respective functions inside headers
-pub fn ui_for_world(world: &mut World, ui: &mut egui::Ui) {
+pub fn ui_for_world(world: &mut World, ui: &mut egui::Ui, hide_observers: &mut bool) {
     egui::CollapsingHeader::new("Entities")
         .default_open(true)
         .show(ui, |ui| {
-            ui_for_entities(world, ui);
+            ui_for_entities(world, ui, hide_observers);
         });
     egui::CollapsingHeader::new("Resources").show(ui, |ui| {
         ui_for_resources(world, ui);
@@ -244,7 +244,7 @@ pub fn ui_for_state<T: FreelyMutableState + Reflect>(world: &mut World, ui: &mut
 /// Includes basic [`EntityFilter`]
 #[deprecated(since = "0.28.1", note = "use ui_for_entities instead")]
 pub fn ui_for_world_entities(world: &mut World, ui: &mut egui::Ui) {
-    ui_for_entities(world, ui);
+    ui_for_entities(world, ui, &mut false);
 }
 /// Display all entities matching the static [`QueryFilter`]
 #[deprecated(since = "0.28.1", note = "use ui_for_entities_filtered instead")]
@@ -257,9 +257,20 @@ pub fn ui_for_world_entities_filtered<QF: WorldQuery + QueryFilter>(
 }
 
 /// Display all root entities.
-pub fn ui_for_entities(world: &mut World, ui: &mut egui::Ui) {
-    let filter: Filter = Filter::from_ui_fuzzy(ui, egui::Id::new("default_world_entities_filter"));
-    ui_for_entities_filtered(world, ui, true, &filter);
+pub fn ui_for_entities(world: &mut World, ui: &mut egui::Ui, hide_observers: &mut bool) {
+    ui.checkbox(hide_observers, "Hide observers");
+
+    if *hide_observers {
+        let filter = Filter::<(Without<ChildOf>, Without<Observer>)>::from_ui_fuzzy(
+            ui,
+            egui::Id::new("default_world_entities_filter"),
+        );
+        ui_for_entities_filtered(world, ui, true, &filter);
+    } else {
+        let filter: Filter =
+            Filter::from_ui_fuzzy(ui, egui::Id::new("default_world_entities_filter"));
+        ui_for_entities_filtered(world, ui, true, &filter);
+    }
 }
 
 /// Display all entities matching the given [`EntityFilter`].

--- a/crates/bevy-inspector-egui/src/lib.rs
+++ b/crates/bevy-inspector-egui/src/lib.rs
@@ -91,7 +91,7 @@
 //!         .run();
 //! }
 //!
-//! fn inspector_ui(world: &mut World) {
+//! fn inspector_ui(world: &mut World, mut hide_observers: Local<bool>) {
 //!     let mut egui_context = world
 //!         .query_filtered::<&mut EguiContext, With<bevy_egui::PrimaryEguiContext>>()
 //!         .single(world)
@@ -101,7 +101,7 @@
 //!     egui::Window::new("UI").show(egui_context.get_mut(), |ui| {
 //!         egui::ScrollArea::both().show(ui, |ui| {
 //!             // equivalent to `WorldInspectorPlugin`
-//!             bevy_inspector::ui_for_world(world, ui);
+//!             bevy_inspector::ui_for_world(world, ui, hide_observers);
 //!
 //!             // works with any `Reflect` value, including `Handle`s
 //!             let mut any_reflect_value: i32 = 5;

--- a/crates/bevy-inspector-egui/src/quick.rs
+++ b/crates/bevy-inspector-egui/src/quick.rs
@@ -88,7 +88,7 @@ impl Plugin for WorldInspectorPlugin {
     }
 }
 
-fn world_inspector_ui(world: &mut World) {
+fn world_inspector_ui(world: &mut World, mut hide_observers: Local<bool>) {
     let egui_context = world
         .query_filtered::<&mut EguiContext, With<PrimaryEguiContext>>()
         .single(world);
@@ -102,7 +102,7 @@ fn world_inspector_ui(world: &mut World) {
         .default_size(DEFAULT_SIZE)
         .show(egui_context.get_mut(), |ui| {
             egui::ScrollArea::both().show(ui, |ui| {
-                bevy_inspector::ui_for_world(world, ui);
+                bevy_inspector::ui_for_world(world, ui, &mut hide_observers);
                 ui.allocate_space(ui.available_size());
             });
         });


### PR DESCRIPTION
This adds a "Hide observers" checkbox to the `WorldInspectorPlugin`.

<img width="529" height="209" alt="check" src="https://github.com/user-attachments/assets/8e9b223f-0b0a-4088-8691-bbe369f05757" />

## Why?

Observers do not derive `Reflect`, we cannot inspect them and they just take up space, in a simple scene they aren't much of an issue, but in more complete and polished games they tend to flood the Entities list so much that it becomes annoying and difficult to find entities.

And as I was working on the 0.19 branch (#315) I noticed the issue becomes a lot worse, the following scene example only spawns 1 camera:

<img width="181" height="512" alt="observer-madness" src="https://github.com/user-attachments/assets/6556ff4f-1c07-4969-82c5-6fcd3f3e03a8" />

## Alternative Solution

Just change the query filter in `Filter`:

```rs
// 0.18
pub struct Filter<F: QueryFilter = (Without<ChildOf>, Without<Observer>)> {
  /* ... */
}

// 0.19
pub struct Filter<F: QueryFilter = (Without<ChildOf>, Without<Observer>, Without<IsResource>)> {
  /* ... */
}
```
