### PR TITLE
Use unmultiplied LinearRgba

### DIFF
--- a/crates/bevy-inspector-egui/src/inspector_egui_impls/bevy_impls.rs
+++ b/crates/bevy-inspector-egui/src/inspector_egui_impls/bevy_impls.rs
@@ -233,10 +233,7 @@ impl InspectorPrimitive for Srgba {
 impl InspectorPrimitive for LinearRgba {
     fn ui(&mut self, ui: &mut egui::Ui, _: &dyn Any, _: egui::Id, _: InspectorUi<'_, '_>) -> bool {
         let mut color = [self.red, self.green, self.blue, self.alpha];
-        if ui
-            .color_edit_button_rgba_unmultiplied(&mut color)
-            .changed()
-        {
+        if ui.color_edit_button_rgba_unmultiplied(&mut color).changed() {
             self.red = color[0];
             self.green = color[1];
             self.blue = color[2];

--- a/crates/bevy-inspector-egui/src/inspector_egui_impls/bevy_impls.rs
+++ b/crates/bevy-inspector-egui/src/inspector_egui_impls/bevy_impls.rs
@@ -234,7 +234,7 @@ impl InspectorPrimitive for LinearRgba {
     fn ui(&mut self, ui: &mut egui::Ui, _: &dyn Any, _: egui::Id, _: InspectorUi<'_, '_>) -> bool {
         let mut color = [self.red, self.green, self.blue, self.alpha];
         if ui
-            .color_edit_button_rgba_premultiplied(&mut color)
+            .color_edit_button_rgba_unmultiplied(&mut color)
             .changed()
         {
             self.red = color[0];


### PR DESCRIPTION
On the inspector if I have a ShaderType that has a LinearRgba and I pick a color on the gui like:
`{ red: 1.0, green: 0.0, blue: 0.0, alpha: 0.5 }`
the LinearRgba value it will pass is:
 `{ red: 0.5, green: 0.0, blue: 0.0, alpha: 0.5 }`
but i'm expecting:
`{ red: 1.0, green: 0.0, blue: 0.0, alpha: 0.5 }`

I know premutliplying has its uses, but I'm not sure why it's done here, so if I'm just missing something let me know.