### PR TITLE
Reorganize bevy features for consistency, add 2d/3d collections

### DIFF
--- a/crates/bevy-inspector-egui/Cargo.toml
+++ b/crates/bevy-inspector-egui/Cargo.toml
@@ -23,9 +23,12 @@ default = [
 ]
 # Enable inspector UI for all optional bevy types
 bevy = [
+    "bevy_camera",
     "bevy_core_pipeline",
     "bevy_gizmos",
     "bevy_image",
+    "bevy_light",
+    "bevy_mesh",
     "bevy_mikktspace",
     "bevy_pbr",
     "bevy_render",
@@ -33,20 +36,30 @@ bevy = [
 # Enable showing documentation on hover.
 documentation = ["bevy_reflect/reflect_documentation"]
 
-# Show inspector UI for bevy_render types
-bevy_render = ["dep:bevy_render", "bevy_egui/render"]
-# Include bevy mikktspace tangents in inspector UI for meshes
-bevy_mikktspace = ["dep:bevy_mikktspace"]
-# Show inspector UI for bevy_gizmos types
-bevy_gizmos = ["dep:bevy_gizmos"]
-# Show inspector UI for bevy_core_pipeline types
-bevy_core_pipeline = ["dep:bevy_core_pipeline"]
-
 egui_clipboard = ["bevy_egui/manage_clipboard"]
 egui_open_url = ["bevy_egui/open_url"]
 
 # Highlight changes to components in a different color.
 highlight_changes = [] # this should ideally be runtime configurable.
+
+# Show inspector UI for `bevy_camera` types
+bevy_camera = ["dep:bevy_camera"]
+# Show inspector UI for `bevy_core_pipeline` types
+bevy_core_pipeline = ["dep:bevy_core_pipeline"]
+# Show inspector UI for `bevy_gizmos` types
+bevy_gizmos = ["dep:bevy_gizmos"]
+# Show inspector UI for `bevy_image` types
+bevy_image = ["dep:bevy_image", "bevy_render"]
+# Show inspector UI for `bevy_light` types
+bevy_light = ["dep:bevy_light"]
+# Show inspector UI for `bevy_mesh` types
+bevy_mesh = ["dep:bevy_mesh"]
+# Show inspector UI for `bevy_mikktspace` types
+bevy_mikktspace = ["dep:bevy_mikktspace"]
+# Show inspector UI for `bevy_pbr` types
+bevy_pbr = ["dep:bevy_pbr"]
+# Show inspector UI for `bevy_render` types
+bevy_render = ["dep:bevy_render", "bevy_egui/render"]
 
 [package.metadata.docs.rs]
 features = ["winit/x11"]
@@ -62,22 +75,22 @@ bevy_color = "0.19.0"
 bevy_platform = "0.19.0"
 bevy_ecs = "0.19.0"
 bevy_log = "0.19.0"
-bevy_camera = "0.19.0"
 bevy_math = "0.19.0"
-bevy_mesh = "0.19.0"
-bevy_light = "0.19.0"
 bevy_reflect = "0.19.0"
 bevy_state = "0.19.0"
 bevy_time = "0.19.0"
 bevy_utils = "0.19.0"
 bevy_window = "0.19.0"
 
-bevy_render = { version = "0.19.0", optional = true }
+bevy_camera = { version = "0.19.0", optional = true }
 bevy_core_pipeline = { version = "0.19.0", optional = true }
-bevy_pbr = { version = "0.19.0", optional = true }
-bevy_image = { version = "0.19.0", optional = true }
 bevy_gizmos = { version = "0.19.0", optional = true }
+bevy_image = { version = "0.19.0", optional = true }
+bevy_light = { version = "0.19.0", optional = true }
+bevy_mesh = { version = "0.19.0", optional = true }
 bevy_mikktspace = { version = "1.0", optional = true }
+bevy_pbr = { version = "0.19.0", optional = true }
+bevy_render = { version = "0.19.0", optional = true }
 
 egui.workspace = true
 bevy_egui = { version = "0.40.0", default-features = false }

--- a/crates/bevy-inspector-egui/Cargo.toml
+++ b/crates/bevy-inspector-egui/Cargo.toml
@@ -39,7 +39,9 @@ bevy = [
 # Enable showing documentation on hover.
 documentation = ["bevy_reflect/reflect_documentation"]
 
+# Enable `bevy_egui` clipboard management
 egui_clipboard = ["bevy_egui/manage_clipboard"]
+# Enable `bevy_egui` ability to open URLs
 egui_open_url = ["bevy_egui/open_url"]
 
 # Highlight changes to components in a different color.

--- a/crates/bevy-inspector-egui/Cargo.toml
+++ b/crates/bevy-inspector-egui/Cargo.toml
@@ -21,18 +21,21 @@ default = [
     "bevy",
     "egui_clipboard",
 ]
-# Enable inspector UI for all optional bevy types
+# COLLECTION: Enable inspector UI for all optional bevy types
 bevy = [
-    "bevy_camera",
-    "bevy_core_pipeline",
+    "2d", "3d",
     "bevy_gizmos",
-    "bevy_image",
-    "bevy_light",
-    "bevy_mesh",
-    "bevy_mikktspace",
-    "bevy_pbr",
-    "bevy_render",
 ]
+# COLLECTION: Enable inspector UI for the bevy 2d collection
+2d = [
+    "bevy_render", "bevy_core_pipeline", "bevy_camera", "bevy_image", "bevy_mesh" # common
+]
+# COLLECTION: Enable inspector UI for the bevy 3d collection
+3d = [
+    "bevy_light", "bevy_mikktspace", "bevy_pbr",
+    "bevy_render", "bevy_core_pipeline", "bevy_camera", "bevy_image", "bevy_mesh" # common
+]
+
 # Enable showing documentation on hover.
 documentation = ["bevy_reflect/reflect_documentation"]
 

--- a/crates/bevy-inspector-egui/src/inspector_egui_impls/bevy_impls.rs
+++ b/crates/bevy-inspector-egui/src/inspector_egui_impls/bevy_impls.rs
@@ -1,3 +1,7 @@
+#[cfg(feature = "bevy_mesh")]
+use bevy_asset::Assets;
+#[cfg(feature = "bevy_mesh")]
+use bevy_asset::Handle;
 use bevy_color::{Color, Hsla, Hsva, LinearRgba, Srgba};
 use bevy_ecs::entity::Entity;
 use bevy_ecs::world::CommandQueue;
@@ -5,13 +9,10 @@ use bevy_ecs::world::World;
 use egui::Color32;
 use std::any::Any;
 
-#[cfg(feature = "bevy_render")]
-use ::{
-    bevy_asset::Assets, bevy_asset::Handle, bevy_camera::visibility::RenderLayers, bevy_mesh::Mesh,
-};
-
-#[cfg(feature = "bevy_render")]
-use crate::bevy_inspector::errors::{no_access, nonexistent_asset_handle};
+#[cfg(feature = "bevy_mesh")]
+use crate::bevy_inspector::errors::no_access;
+#[cfg(feature = "bevy_mesh")]
+use crate::bevy_inspector::errors::nonexistent_asset_handle;
 use crate::{
     bevy_inspector::errors::no_world_in_context,
     egui_utils,
@@ -94,8 +95,8 @@ impl InspectorPrimitive for Entity {
     }
 }
 
-#[cfg(feature = "bevy_render")]
-impl InspectorPrimitive for Handle<Mesh> {
+#[cfg(feature = "bevy_mesh")]
+impl InspectorPrimitive for Handle<bevy_mesh::Mesh> {
     fn ui(
         &mut self,
         ui: &mut egui::Ui,
@@ -108,7 +109,7 @@ impl InspectorPrimitive for Handle<Mesh> {
             no_world_in_context(ui, "Handle<Mesh>");
             return false;
         };
-        let mut meshes = match world.get_resource_mut::<Assets<Mesh>>() {
+        let mut meshes = match world.get_resource_mut::<Assets<bevy_mesh::Mesh>>() {
             Ok(meshes) => meshes,
             Err(error) => {
                 no_access(error, ui, "Assets<Mesh>");
@@ -148,7 +149,7 @@ impl InspectorPrimitive for Handle<Mesh> {
             no_world_in_context(ui, "Handle<Mesh>");
             return;
         };
-        let meshes = match world.get_resource_mut::<Assets<Mesh>>() {
+        let meshes = match world.get_resource_mut::<Assets<bevy_mesh::Mesh>>() {
             Ok(meshes) => meshes,
             Err(error) => return no_access(error, ui, "Assets<Mesh>"),
         };
@@ -160,8 +161,8 @@ impl InspectorPrimitive for Handle<Mesh> {
     }
 }
 
-#[cfg(feature = "bevy_render")]
-fn mesh_ui_inner(mesh: &Mesh, ui: &mut egui::Ui) {
+#[cfg(feature = "bevy_mesh")]
+fn mesh_ui_inner(mesh: &bevy_mesh::Mesh, ui: &mut egui::Ui) {
     egui::Grid::new("mesh").show(ui, |ui| {
         ui.label("primitive_topology");
         ui.label(format!("{:?}", mesh.primitive_topology()));
@@ -184,14 +185,14 @@ fn mesh_ui_inner(mesh: &Mesh, ui: &mut egui::Ui) {
         ui.label("Vertex Attributes");
 
         let builtin_attributes = &[
-            Mesh::ATTRIBUTE_POSITION,
-            Mesh::ATTRIBUTE_COLOR,
-            Mesh::ATTRIBUTE_UV_0,
-            Mesh::ATTRIBUTE_NORMAL,
-            Mesh::ATTRIBUTE_TANGENT,
-            Mesh::ATTRIBUTE_COLOR,
-            Mesh::ATTRIBUTE_JOINT_INDEX,
-            Mesh::ATTRIBUTE_JOINT_WEIGHT,
+            bevy_mesh::Mesh::ATTRIBUTE_POSITION,
+            bevy_mesh::Mesh::ATTRIBUTE_COLOR,
+            bevy_mesh::Mesh::ATTRIBUTE_UV_0,
+            bevy_mesh::Mesh::ATTRIBUTE_NORMAL,
+            bevy_mesh::Mesh::ATTRIBUTE_TANGENT,
+            bevy_mesh::Mesh::ATTRIBUTE_COLOR,
+            bevy_mesh::Mesh::ATTRIBUTE_JOINT_INDEX,
+            bevy_mesh::Mesh::ATTRIBUTE_JOINT_WEIGHT,
         ];
 
         ui.vertical(|ui| {
@@ -347,8 +348,8 @@ impl InspectorPrimitive for Color {
     }
 }
 
-#[cfg(feature = "bevy_render")]
-impl InspectorPrimitive for RenderLayers {
+#[cfg(feature = "bevy_camera")]
+impl InspectorPrimitive for bevy_camera::visibility::RenderLayers {
     fn ui(&mut self, ui: &mut egui::Ui, _: &dyn Any, id: egui::Id, _: InspectorUi<'_, '_>) -> bool {
         let mut new_value = None;
         egui::Grid::new(id).num_columns(2).show(ui, |ui| {

--- a/crates/bevy-inspector-egui/src/inspector_egui_impls/mod.rs
+++ b/crates/bevy-inspector-egui/src/inspector_egui_impls/mod.rs
@@ -325,18 +325,23 @@ pub fn register_bevy_impls(type_registry: &mut TypeRegistry) {
     add::<bevy_color::Hsla>(type_registry);
     add::<bevy_color::Hsva>(type_registry);
 
-    #[cfg(feature = "bevy_render")]
+    #[cfg(feature = "bevy_camera")]
     {
-      type_registry.register::<bevy_camera::visibility::RenderLayers>();
-      add_of_with_many::<bevy_asset::Handle<bevy_mesh::Mesh>>(type_registry, many_unimplemented::<bevy_asset::Handle<bevy_mesh::Mesh>>);
-      add::<bevy_camera::visibility::RenderLayers>(type_registry);
+        type_registry.register::<bevy_camera::visibility::RenderLayers>();
+        add::<bevy_camera::visibility::RenderLayers>(type_registry);
+    }
+    #[cfg(feature = "bevy_mesh")]
+    {
+        add_of_with_many::<bevy_asset::Handle<bevy_mesh::Mesh>>(type_registry, many_unimplemented::<bevy_asset::Handle<bevy_mesh::Mesh>>);
     }
     #[cfg(feature = "bevy_image")]
     {
-      add_of_with_many::<bevy_asset::Handle<bevy_image::Image>>(type_registry, many_unimplemented::<bevy_asset::Handle<bevy_image::Image>>);
+        add_of_with_many::<bevy_asset::Handle<bevy_image::Image>>(type_registry, many_unimplemented::<bevy_asset::Handle<bevy_image::Image>>);
     }
     #[cfg(feature = "bevy_gizmos")]
-    add::<bevy_gizmos::config::GizmoConfigStore>(type_registry);
+    {
+        add::<bevy_gizmos::config::GizmoConfigStore>(type_registry);
+    }
 
     add::<uuid::Uuid>(type_registry);
 }

--- a/crates/bevy-inspector-egui/src/inspector_options/default_options.rs
+++ b/crates/bevy-inspector-egui/src/inspector_options/default_options.rs
@@ -161,6 +161,15 @@ pub fn register_default_options(type_registry: &mut TypeRegistry) {
         ],
     );
 
+    type_registry.register::<bevy_time::Virtual>();
+    insert_options_struct::<bevy_time::Virtual>(
+        type_registry,
+        &[
+            ("relative_speed", &NumberOptions::<f64>::positive()),
+            ("effective_speed", &NumberOptions::<f64>::positive()),
+        ],
+    );
+
     #[cfg(feature = "bevy_render")]
     {
         #[rustfmt::skip]
@@ -189,16 +198,12 @@ pub fn register_default_options(type_registry: &mut TypeRegistry) {
         );
     }
 
-    #[cfg(feature = "bevy_pbr")]
+    #[cfg(feature = "bevy_light")]
     {
-        #[rustfmt::skip]
         insert_options_struct::<bevy_light::AmbientLight>(
             type_registry,
-            &[
-                ("brightness", &NumberOptions::<f32>::positive()),
-            ],
+            &[("brightness", &NumberOptions::<f32>::positive())],
         );
-
         insert_options_struct::<bevy_light::PointLight>(
             type_registry,
             &[
@@ -208,23 +213,9 @@ pub fn register_default_options(type_registry: &mut TypeRegistry) {
             ],
         );
 
-        #[rustfmt::skip]
         insert_options_struct::<bevy_light::DirectionalLight>(
             type_registry,
-            &[
-                ("illuminance", &NumberOptions::<f32>::positive()),
-            ],
-        );
-
-        #[rustfmt::skip]
-        insert_options_struct::<bevy_pbr::StandardMaterial>(
-            type_registry,
-            &[
-                ("perceptual_roughness", &NumberOptions::<f32>::between(0.089, 1.0)),
-                ("metallic", &NumberOptions::<f32>::normalized()),
-                ("reflectance", &NumberOptions::<f32>::normalized()),
-                ("depth_bias", &NumberOptions::<f32>::positive()),
-            ],
+            &[("illuminance", &NumberOptions::<f32>::positive())],
         );
 
         #[rustfmt::skip]
@@ -237,22 +228,26 @@ pub fn register_default_options(type_registry: &mut TypeRegistry) {
         );
     }
 
+    #[cfg(feature = "bevy_pbr")]
+    {
+        #[rustfmt::skip]
+        insert_options_struct::<bevy_pbr::StandardMaterial>(
+            type_registry,
+            &[
+                ("perceptual_roughness", &NumberOptions::<f32>::between(0.089, 1.0)),
+                ("metallic", &NumberOptions::<f32>::normalized()),
+                ("reflectance", &NumberOptions::<f32>::normalized()),
+                ("depth_bias", &NumberOptions::<f32>::positive()),
+            ],
+        );
+    }
+
     #[rustfmt::skip]
-    #[cfg(feature = "bevy_core_pipeline")]
+    #[cfg(feature = "bevy_camera")]
     insert_options_enum::<bevy_camera::Camera3dDepthLoadOp>(
         type_registry,
         &[
             ("Clear", "0", &NumberOptions::<f32>::normalized()),
-        ],
-    );
-
-    type_registry.register::<bevy_time::Virtual>();
-
-    insert_options_struct::<bevy_time::Virtual>(
-        type_registry,
-        &[
-            ("relative_speed", &NumberOptions::<f64>::positive()),
-            ("effective_speed", &NumberOptions::<f64>::positive()),
         ],
     );
 }

--- a/crates/bevy-inspector-egui/src/inspector_options/default_options.rs
+++ b/crates/bevy-inspector-egui/src/inspector_options/default_options.rs
@@ -250,4 +250,15 @@ pub fn register_default_options(type_registry: &mut TypeRegistry) {
             ("Clear", "0", &NumberOptions::<f32>::normalized()),
         ],
     );
+
+    #[rustfmt::skip]
+    #[cfg(feature = "bevy_core_pipeline")]
+    insert_options_struct::<bevy_core_pipeline::oit::OrderIndependentTransparencySettings>(
+        type_registry,
+        &[
+            ("sorted_fragment_max_count", &NumberOptions::<u32>::at_least(1)),
+            ("fragments_per_pixel_average", &NumberOptions::<f32>::positive()),
+            ("alpha_threshold", &NumberOptions::<f32>::normalized()),
+        ],
+    );
 }


### PR DESCRIPTION
inspired by #309

- Make each bevy feature (bevy_camera bevy_core_pipeline bevy_gizmos bevy_image bevy_light bevy_mesh bevy_mikktspace bevy_pbr bevy_render) optional and consistent in `Cargo.toml`
- add `2d`/`3d` collections enabling everything that would be enabled by the equivalent bevy collection