### PR TITLE
bevy_egui 0.41 + egui 0.35

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,5 +3,5 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.dependencies]
-egui = "0.34"
-bevy_egui = "0.40.0"
+egui = "0.35"
+bevy_egui = "0.41.0"

--- a/crates/bevy-inspector-egui/Cargo.toml
+++ b/crates/bevy-inspector-egui/Cargo.toml
@@ -98,7 +98,7 @@ bevy_pbr = { version = "0.19.0", optional = true }
 bevy_render = { version = "0.19.0", optional = true }
 
 egui.workspace = true
-bevy_egui = { version = "0.40.0", default-features = false }
+bevy_egui = { version = "0.41.0", default-features = false }
 
 bytemuck = "1.16.0"
 image = { version = "0.25", default-features = false }
@@ -133,7 +133,7 @@ bevy = { version = "0.19.0", default-features = false, features = [
     "ktx2",
 ] }
 bevy_math = { version = "0.19.0", features = ["mint"] }
-egui_dock = "0.19.1"
+egui_dock = "0.20.1"
 # transform-gizmo-bevy = { git = "https://github.com/taboky-dev/transform-gizmo", branch = "bevy-0.18" }
 # bevy_mod_picking = { git = "https://github.com/aevyrie/bevy_mod_picking", rev = "554649a951689dce66d0d759839b326874e8826f", default-features = false, features = ["backend_raycast", "backend_egui", "backend_sprite"] }
 # bevy_framepace = "0.11"

--- a/crates/bevy-inspector-egui/src/dropdown.rs
+++ b/crates/bevy-inspector-egui/src/dropdown.rs
@@ -27,7 +27,7 @@ impl<'a, F: FnMut(&mut Ui, &str) -> Response, V: AsRef<str>, I: Iterator<Item = 
     /// Creates new dropdown box.
     pub fn from_iter(
         it: impl IntoIterator<IntoIter = I>,
-        id_source: impl Hash,
+        id_source: impl Hash + std::fmt::Debug,
         buf: &'a mut String,
         display: F,
     ) -> Self {


### PR DESCRIPTION
`bevy_egui` recently updated `egui` to v0.35.

```toml
[dependencies]
bevy_egui = "0.41.0"
bevy-inspector-egui = { git = "https://github.com/taboky-dev/bevy-inspector-egui.git", rev = "6d58074" }
```